### PR TITLE
Added note to Web Flows chapter: plugin needs to be installed first

### DIFF
--- a/src/guide/6.5 Web Flow.gdoc
+++ b/src/guide/6.5 Web Flow.gdoc
@@ -8,6 +8,10 @@ Web flow is essentially an advanced state machine that manages the "flow" of exe
 
 h4. Creating a Flow
 
+{note}
+Since Grails 1.2 the web flow plugin is not installed by default. Use 'grails install-plugin webflow' to install the plugin and enable this feature. 
+{note}
+
 To create a flow create a regular Grails controller and then add an action that ends with the convention @Flow@. For example:
 
 {code:java}


### PR DESCRIPTION
Hi,

We spent too much time today scratching our heads as to why the very basic Web Flows examples were not working in our project. I eventually figured out that the webflow plugin is not installed by default. I've added a note to the top of the Web Flows chapter to point this out and hopefully save others the pain.

Martin Dow.
