### PR TITLE
Grails 6174

### DIFF
--- a/src/ref/Tags/form.gdoc
+++ b/src/ref/Tags/form.gdoc
@@ -38,7 +38,7 @@ Attributes
 
 * @action@ (optional) - the name of the action to use in the link, if not specified the default action will be linked
 * @controller@ (optional) - the name of the controller to use in the link, if not specified the current controller will be linked
-* @id@ (optional) - The id to use in the link
+* @id@ (optional) - The id to use in the link. (To generate an id attribute on the resulting html form tag, use the name attribute instead.)
 * @url@ (optional) - A map containing the action,controller,id etc.
 * @name@ (optional) - A value to use for both the name and id attribute of the form tag
 * @useToken@ (optional) - Set whether to send a token in the request to handle duplicate form submissions. See [Handling Duplicate Form Submissions|guide:formtokens]


### PR DESCRIPTION
Increased Clarity of the Form Tag documentation. 
Note: this was done in a Live SpringOne2gx talk!!
