### PR TITLE
GRAILS-5182 - Documentation doesn't mention that a domain class version type can be Timestamp

### DIFF
--- a/src/ref/Database Mapping/version.gdoc
+++ b/src/ref/Database Mapping/version.gdoc
@@ -35,3 +35,10 @@ static mapping = {
 }
 {code}
 
+The @timestamp@ type is also supported by Grails:
+
+{code}
+class Book {
+    Timestamp version
+}
+{code}


### PR DESCRIPTION
Another minor addition to the docs.
