### PR TITLE
GRAILS-4577

### DIFF
--- a/src/guide/8.1 Declarative Transactions.gdoc
+++ b/src/guide/8.1 Declarative Transactions.gdoc
@@ -17,7 +17,7 @@ Warning: [dependency injection|guide:8.3 Dependency Injection and Services] is t
 {warning}
 
 
-The result is all methods are wrapped in a transaction and automatic rollback occurs if an exception is thrown in the body of one of the methods. The propagation level of the transaction is by default set to [PROPAGATION_REQUIRED|http://static.springsource.org/spring/docs/3.0.x/javadoc-api/org/springframework/transaction/TransactionDefinition.html#PROPAGATION_REQUIRED].
+The result is all methods are wrapped in a transaction and automatic rollback occurs if an @RuntimeException@ is thrown in the body of one of the methods. Throwing any checked @Exception@ does *not* have any effect. The propagation level of the transaction is by default set to [PROPAGATION_REQUIRED|http://static.springsource.org/spring/docs/3.0.x/javadoc-api/org/springframework/transaction/TransactionDefinition.html#PROPAGATION_REQUIRED].
 
 h3. Custom Transaction Configuration
 


### PR DESCRIPTION
GRAILS-4577: added note that only RuntimeException will trigger a rollback but checked exceptions won't. Comment according to http://static.springsource.org/spring/docs/3.0.x/spring-framework-reference/html/transaction.html section 10.5.6.1 @Transactional settings.
