### PR TITLE
Grails 7225

### DIFF
--- a/src/ref/Tags/renderErrors.gdoc
+++ b/src/ref/Tags/renderErrors.gdoc
@@ -21,7 +21,7 @@ h2. Description
 
 Attributes
 
-* @as@ (optional) - What to render it as current options are "list". Defaults to "list" if not specified.
+* @as@ (optional) - What to render it as current options are "list" and "xml". Defaults to "list" if not specified.
 * @bean@ (optional) - The name of the bean to check for errors
 * @model@ (optional) - The name of model, an map instance, to check for errors
 * @field@ (optional) - The field within the bean or model to check for errors for


### PR DESCRIPTION
GRAILS-7225: Added hint on xml option for "as" attribute as suggested in the issue description.
