### PR TITLE
Fix a path

### DIFF
--- a/src/guide/3.6 Project Documentation.gdoc
+++ b/src/guide/3.6 Project Documentation.gdoc
@@ -18,7 +18,7 @@ h4. Creating reference items
 Reference items appear in the left menu on the documentation and are useful for quick reference documentation. Each reference item belongs to a category and a category is a directory located in the @src/docs/ref@ directory. For example say you defined a new method called @renderPDF@, that belongs to a category called @Controllers@ this can be done by creating a gdoc text file at the following location:
 
 {code}
-+ src/ref/Controllers/renderPDF.gdoc
++ src/docs/ref/Controllers/renderPDF.gdoc
 {code}
 
 h4. Configuring Output Properties


### PR DESCRIPTION
Code example points to the wrong location for reference material when creating Grails documentation for a project.
