### PR TITLE
documentation for GRAILS-7366 & GRAILS-7154 adding readOnly, fetchSize, timeout, and flushMode to dynamic finders/executeQuery

### DIFF
--- a/src/ref/Domain Classes/executeQuery.gdoc
+++ b/src/ref/Domain Classes/executeQuery.gdoc
@@ -19,6 +19,14 @@ Account.executeQuery( "select distinct a.number from Account a where a.branch = 
 Account.executeQuery( "select distinct a.number from Account a where a.branch = :branch", [branch:'London', max:10, offset:5] );
 // same as previous
 Account.executeQuery( "select distinct a.number from Account a where a.branch = :branch", [branch:'London'], [max:10, offset:5] );
+// tell underlying Hibernate Query object to not attach newly retrieved objects to the session, will only save with explicit @save@
+Account.executeQuery( "select distinct a.number from Account a", null, [readOnly: true])
+// time request out after 18 seconds
+Account.executeQuery( "select distinct a.number from Account a", null, [timeout: 18])
+// have Hibernate Query object return 30 rows at a time
+Account.executeQuery( "select distinct a.number from Account a", null, [fetchSize: 30])
+// modify the FlushMode of the Query (default is @FlushMode.AUTO@)
+Account.executeQuery( "select distinct a.number from Account a", null, [flushMode: FlushMode.MANUAL])
 
 {code}
 
@@ -29,9 +37,9 @@ The @executeQuery@ method allows the execution of arbitrary HQL queries that don
 {code:java}
 Book.executeQuery( String query )
 Book.executeQuery( String query, Collection positionalParams )
-Book.executeQuery( String query, Collection positionalParams, Map paginateParams )
+Book.executeQuery( String query, Collection positionalParams, Map metaParams )
 Book.executeQuery( String query, Map namedParams )
-Book.executeQuery( String query, Map namedParams, Map paginateParams )
+Book.executeQuery( String query, Map namedParams, Map metaParams )
 {code}
 
 Parameters:
@@ -39,4 +47,4 @@ Parameters:
 * @query@ - An HQL query
 * @positionalParams@ - A List of parameters for a positional parametrized HQL query
 * @namedParams@ - A Map of named parameters a HQL query
-* @paginateParams@ - A Map containing parameters 'max' or/and 'offset' (see examples below)
+* @metaParams@ - A Map containing pagination parameters @max@ or/and @offset@, as well as hibernate query parameters @readOnly@, @fetchSize@, @timeout@, and @flushMode@.  (see examples above)

--- a/src/ref/Domain Classes/findAll.gdoc
+++ b/src/ref/Domain Classes/findAll.gdoc
@@ -71,3 +71,8 @@ Parameters:
 * @namedParams@ - A Map of named parameters a HQL query
 * @queryParams@ - A Map containing parameters 'max', and/or 'offset' and/or 'cache'
 * @example@ - An instance of the domain class for query by example
+* @readOnly@ - true if returned objects should not be automatically dirty-checked (simlar to @read()@)
+* @fetchSize@ - number of rows fetched by the underlying JDBC driver per round trip
+* @flushMode@ - Hibernate @FlushMode@ override, defaults to @FlushMode.AUTO@
+* @timeout@ - query timeout in seconds
+

--- a/src/ref/Domain Classes/findAllBy.gdoc
+++ b/src/ref/Domain Classes/findAllBy.gdoc
@@ -42,7 +42,7 @@ GORM supports the notion of [Dynamic Finders|guide:finders]. The @findAllBy*@ me
 
 Parameters:
 
-* @paginateParams@ - A Map containing parameters @max@, @order@, @offset@ and @sort@
+* @metaParams@ - A Map containing pagination parameters @max@, @order@, @offset@ and @sort@ and metaParameters @readOnly@, @timeout@, @fetchSize@, and @flushMode@
 
 Pagination and sorting parameters can be used as the last argument to a dynamic method:
 

--- a/src/ref/Domain Classes/list.gdoc
+++ b/src/ref/Domain Classes/list.gdoc
@@ -30,5 +30,9 @@ Parameters:
 * @sort@ - The property name to sort by
 * @ignoreCase@ - Whether to ignore the case when sorting. Default is @true@.
 * @fetch@ - The fetch policy for the object's associations as a Map
+* @readOnly@ - true if returned objects should not be automatically dirty-checked (simlar to @read()@)
+* @fetchSize@ - number of rows fetched by the underlying JDBC driver per round trip
+* @flushMode@ - Hibernate @FlushMode@ override, defaults to @FlushMode.AUTO@
+* @timeout@ - query timeout in seconds
 
 


### PR DESCRIPTION
documentation for GRAILS-7366 & GRAILS-7154 adding readOnly, fetchSize, timeout, and flushMode to dynamic finders/executeQuery
