### PR TITLE
gradlew.bat update

### DIFF
--- a/gradlew.bat
+++ b/gradlew.bat
@@ -10,7 +10,7 @@ if "%OS%"=="Windows_NT" setlocal
 
 @rem Uncomment those lines to set JVM options. GRADLE_OPTS and JAVA_OPTS can be used together.
 @rem set GRADLE_OPTS=%GRADLE_OPTS% -Xmx512m
-@rem set JAVA_OPTS=%JAVA_OPTS% -Xmx512m
+set JAVA_OPTS=%JAVA_OPTS% -Xmx1024m -XX:MaxPermSize=256m
 
 set DIRNAME=%~dp0
 if "%DIRNAME%" == "" set DIRNAME=.\


### PR DESCRIPTION
Fixing PermGen memory error while building on Windows. Copied JAVA_OPTS values from UNIX script.
