### PR TITLE
fix typo

### DIFF
--- a/src/guide/14.5 Property Placeholder Configuration.gdoc
+++ b/src/guide/14.5 Property Placeholder Configuration.gdoc
@@ -1,6 +1,6 @@
 Grails supports the notion of property placeholder configuration through an extended version of Spring's [PropertyPlaceholderConfigurer|api:org.springframework.beans.factory.config.PropertyPlaceholderConfigurer], which is typically useful when used in combination with [externalized configuration|guide:3.4 Externalized Configuration].
 
-Settings defined in either "ConfigSlurper":http://groovy.codehaus.org/ConfigSlurper scripts of Java properties files can be used as placeholder values for Spring configuration in @grails-app/conf/spring/resources.xml@. For example given the following entries in @grails-app/conf/Config.groovy@ (or an externalized config):
+Settings defined in either "ConfigSlurper":http://groovy.codehaus.org/ConfigSlurper scripts or Java properties files can be used as placeholder values for Spring configuration in @grails-app/conf/spring/resources.xml@. For example given the following entries in @grails-app/conf/Config.groovy@ (or an externalized config):
 
 {code:java}
 database.driver="com.mysql.jdbc.Driver"


### PR DESCRIPTION
guide, 14.5 Property Placeholder Configuration

replace "Settings defined in either ConfigSlurper scripts of Java properties files ..."
with      "Settings defined in either ConfigSlurper scripts or Java properties files ..."
