### PR TITLE
removed superfluous strikethrough from command line "integrate-with"

### DIFF
--- a/src/ref/Command Line/integrate-with.gdoc
+++ b/src/ref/Command Line/integrate-with.gdoc
@@ -17,9 +17,9 @@ Usage:
 grails integrate-with [ARGUMENTS]
 {code}
 
-The @integrate-with@ command will integrate Grails with different IDEs and build systems based on the arguments provided. For example the @\--eclipse@ command will produce @.project@ and @.classpath@ files for use with Eclipse or [SpringSource Tool Suite (STS)|http://www.springsource.com/products/sts].
+The @integrate-with@ command will integrate Grails with different IDEs and build systems based on the arguments provided. For example the @\-eclipse@ command will produce @.project@ and @.classpath@ files for use with Eclipse or [SpringSource Tool Suite (STS)|http://www.springsource.com/products/sts].
 
-The command is extensible. For example to provide a @\--myide@ command, create an @_Events.groovy@ file and handle the @IntegrateWithStart@ event:
+The command is extensible. For example to provide a @\-myide@ command, create an @_Events.groovy@ file and handle the @IntegrateWithStart@ event:
 
 {code}
 eventIntegrateWithStart = {


### PR DESCRIPTION
as reported in http://grails.1312388.n4.nabble.com/Grails-doc-integrate-with-td3505463.html
apparently it has yet to be committed (?)
