### PR TITLE
Document plugins scopes and environments as mentioned in 1.1 release note

### DIFF
--- a/src/guide/12.12 Scopes and Environments.gdoc
+++ b/src/guide/12.12 Scopes and Environments.gdoc
@@ -1,0 +1,8 @@
+Plugins can be scoped using either the environment or predefined build scopes:
+
+{code}
+def environments = ['dev', 'test']
+def scopes = [excludes:'war']
+{code}
+
+The plugins will only load in those environments and will not be packaged into the WAR file. This allows @development-only@ plugins to not be packaged for production use.


### PR DESCRIPTION
Document plugins scopes and environments as mentioned in 1.1 release notes.

Release notes documentation:
http://grails.org/1.1+Release+Notes

More info:
- http://jira.grails.org/browse/GRAILS-6517
- http://stackoverflow.com/questions/1783487/is-it-possible-to-exclude-grails-plugin-from-production-environment
