### PR TITLE
A request to add ZK-Grails into the Ajax section of the doc.

### DIFF
--- a/src/en/guide/theWebLayer/ajax/ajaxWithZK.gdoc
+++ b/src/en/guide/theWebLayer/ajax/ajaxWithZK.gdoc
@@ -1,0 +1,1 @@
+Grails also supports the server-side Ajax programming model. This model allows developers to create RIA applications using only Grails artifacts and Groovy codes via the "ZK framework":http://zkoss.org/ through a set of plugins. The documentation is available "here":http://grails.org/plugin/zk.


### PR DESCRIPTION
Hi,

As ZKGrails is a healthy plugin that has been released along with Grails more than 3 years. Would you mind if I'd like to add its reference into the Grails Ajax section, besides GWT? This would also be broaden Grails to the better cover the server-side Ajax, which is not well supported by other frameworks.
