### PR TITLE
Docs for grails.doc.title/subtitle

### DIFF
--- a/src/en/guide/conf/docengine.gdoc
+++ b/src/en/guide/conf/docengine.gdoc
@@ -47,12 +47,14 @@ h4. Configuring Output Properties
 
 There are various properties you can set within your @grails-app/conf/Config.groovy@ file that customize the output of the documentation such as:
 
+* *grails.doc.title* - The title of the documentation
+* *grails.doc.subtitle* - The subtitle of the documentation
 * *grails.doc.authors* - The authors of the documentation
 * *grails.doc.license* - The license of the software
 * *grails.doc.copyright* - The copyright message to display
 * *grails.doc.footer* - The footer to use
 
-Other properties such as the name of the documentation and the version are pulled from your project itself.
+Other properties such as the version are pulled from your project itself.  If a title is not specified, the application name is used.
 
 h4. Generating Documentation
 


### PR DESCRIPTION
Settings for grails.doc.title and grails.doc.subtitle are not included in the current documentation even though they are supported.  I had to dig through grails-doc to find them.  I've added notes about each as well as noting that the application name is the default for the title if not supplied.
