### PR TITLE
Update doWithWebDescriptor class type

### DIFF
--- a/src/guide/12.7 Hooking into Runtime Configuration.gdoc
+++ b/src/guide/12.7 Hooking into Runtime Configuration.gdoc
@@ -28,7 +28,7 @@ This plugin sets up the Grails @messageSource@ bean and a couple of other beans 
 
 h4. Participating in web.xml Generation
 
-Grails generates the @WEB-INF/web.xml@ file at load time, and although plugins cannot change this file directly, they can participate in the generation of the file. Essentially a plugin can provide a @doWithWebDescriptor@ property that is assigned a block of code that gets passed the @web.xml@ as a @XmlSlurper@ @GPathResult@.
+Grails generates the @WEB-INF/web.xml@ file at load time, and although plugins cannot change this file directly, they can participate in the generation of the file. Essentially a plugin can provide a @doWithWebDescriptor@ property that is assigned a block of code that gets passed the @web.xml@ as a @org.w3c.dom.Element@ decorated with @groovy.xml.dom.DOMCategory@ metamethods.
 
 Consider the below example from the @ControllersPlugin@:
 


### PR DESCRIPTION
Grails 2 changed the parameter of doWithWebDescriptor from a GPathResult to a decorated Element object.
