### PR TITLE
Fix broken link to ConfigSlurper from the "configuration" documentation

### DIFF
--- a/src/en/guide/conf/environments.gdoc
+++ b/src/en/guide/conf/environments.gdoc
@@ -1,6 +1,6 @@
 h4. Per Environment Configuration
 
-Grails supports the concept of per environment configuration. The @Config.groovy@, @DataSource.groovy@, and @BootStrap.groovy@ files in the @grails-app/conf@ directory can use per-environment configuration using the syntax provided by "ConfigSlurper":http://groovy.codehaus.org/ConfigSlurper. As an example consider the following default @DataSource@ definition provided by Grails:
+Grails supports the concept of per environment configuration. The @Config.groovy@, @DataSource.groovy@, and @BootStrap.groovy@ files in the @grails-app/conf@ directory can use per-environment configuration using the syntax provided by [ConfigSlurper|http://groovy.codehaus.org/ConfigSlurper]. As an example consider the following default @DataSource@ definition provided by Grails:
 
 {code:java}
 dataSource {

--- a/src/es/guide/conf/environments.gdoc
+++ b/src/es/guide/conf/environments.gdoc
@@ -2,13 +2,13 @@
 
 h4. Per Environment Configuration
 
-Grails supports the concept of per environment configuration. The @Config.groovy@, @DataSource.groovy@, and @BootStrap.groovy@ files in the @grails-app/conf@ directory can use per-environment configuration using the syntax provided by "ConfigSlurper":http://groovy.codehaus.org/ConfigSlurper. As an example consider the following default @DataSource@ definition provided by Grails:
+Grails supports the concept of per environment configuration. The @Config.groovy@, @DataSource.groovy@, and @BootStrap.groovy@ files in the @grails-app/conf@ directory can use per-environment configuration using the syntax provided by [ConfigSlurper|http://groovy.codehaus.org/ConfigSlurper]. As an example consider the following default @DataSource@ definition provided by Grails:
 
 {hidden}
 
 h4. Configuración por entornos
 
-Grails es compatible con el concepto de configuración por entornos. Los archivos @Config.groovy@, @DataSource.groovy@ y @BootStrap.groovy@ en el directorio @grails-app/conf@ pueden utilizar configuración por entorno por medio con la sintaxis proporcionada por "ConfigSlurper":http://groovy.codehaus.org/ConfigSlurper. Como ejemplo, considere la siguiente definición por defecto del @DataSource@ proporcionada por Grails:
+Grails es compatible con el concepto de configuración por entornos. Los archivos @Config.groovy@, @DataSource.groovy@ y @BootStrap.groovy@ en el directorio @grails-app/conf@ pueden utilizar configuración por entorno por medio con la sintaxis proporcionada por [ConfigSlurper|http://groovy.codehaus.org/ConfigSlurper].  Como ejemplo, considere la siguiente definición por defecto del @DataSource@ proporcionada por Grails:
 
 {code:java}
 dataSource {

--- a/src/fr/guide/conf/environments.gdoc
+++ b/src/fr/guide/conf/environments.gdoc
@@ -1,6 +1,6 @@
 h4. Per Environment Configuration
 
-Grails supports the concept of per environment configuration. The @Config.groovy@, @DataSource.groovy@, and @BootStrap.groovy@ files in the @grails-app/conf@ directory can use per-environment configuration using the syntax provided by "ConfigSlurper":http://groovy.codehaus.org/ConfigSlurper. As an example consider the following default @DataSource@ definition provided by Grails:
+Grails supports the concept of per environment configuration. The @Config.groovy@, @DataSource.groovy@, and @BootStrap.groovy@ files in the @grails-app/conf@ directory can use per-environment configuration using the syntax provided by [ConfigSlurper|http://groovy.codehaus.org/ConfigSlurper]. As an example consider the following default @DataSource@ definition provided by Grails:
 
 {code:java}
 dataSource {

--- a/src/pt_PT/guide/conf/environments.gdoc
+++ b/src/pt_PT/guide/conf/environments.gdoc
@@ -1,6 +1,6 @@
 h4. Per Environment Configuration
 
-Grails supports the concept of per environment configuration. The @Config.groovy@, @DataSource.groovy@, and @BootStrap.groovy@ files in the @grails-app/conf@ directory can use per-environment configuration using the syntax provided by "ConfigSlurper":http://groovy.codehaus.org/ConfigSlurper. As an example consider the following default @DataSource@ definition provided by Grails:
+Grails supports the concept of per environment configuration. The @Config.groovy@, @DataSource.groovy@, and @BootStrap.groovy@ files in the @grails-app/conf@ directory can use per-environment configuration using the syntax provided by [ConfigSlurper|http://groovy.codehaus.org/ConfigSlurper]. As an example consider the following default @DataSource@ definition provided by Grails:
 
 {code:java}
 dataSource {

--- a/src/th/guide/conf/environments.gdoc
+++ b/src/th/guide/conf/environments.gdoc
@@ -1,6 +1,6 @@
 h4. Per Environment Configuration
 
-Grails supports the concept of per environment configuration. The @Config.groovy@, @DataSource.groovy@, and @BootStrap.groovy@ files in the @grails-app/conf@ directory can use per-environment configuration using the syntax provided by "ConfigSlurper":http://groovy.codehaus.org/ConfigSlurper. As an example consider the following default @DataSource@ definition provided by Grails:
+Grails supports the concept of per environment configuration. The @Config.groovy@, @DataSource.groovy@, and @BootStrap.groovy@ files in the @grails-app/conf@ directory can use per-environment configuration using the syntax provided by [ConfigSlurper|http://groovy.codehaus.org/ConfigSlurper]. As an example consider the following default @DataSource@ definition provided by Grails:
 
 {code:java}
 dataSource {

--- a/src/zh_CN/guide/conf/environments.gdoc
+++ b/src/zh_CN/guide/conf/environments.gdoc
@@ -1,6 +1,6 @@
 h4. Per Environment Configuration
 
-Grails supports the concept of per environment configuration. The @Config.groovy@, @DataSource.groovy@, and @BootStrap.groovy@ files in the @grails-app/conf@ directory can use per-environment configuration using the syntax provided by "ConfigSlurper":http://groovy.codehaus.org/ConfigSlurper. As an example consider the following default @DataSource@ definition provided by Grails:
+Grails supports the concept of per environment configuration. The @Config.groovy@, @DataSource.groovy@, and @BootStrap.groovy@ files in the @grails-app/conf@ directory can use per-environment configuration using the syntax provided by [ConfigSlurper|http://groovy.codehaus.org/ConfigSlurper]. As an example consider the following default @DataSource@ definition provided by Grails:
 
 {code:java}
 dataSource {

--- a/src/zh_TW/guide/conf/environments.gdoc
+++ b/src/zh_TW/guide/conf/environments.gdoc
@@ -1,6 +1,6 @@
 h4. Per Environment Configuration
 
-Grails supports the concept of per environment configuration. The @Config.groovy@, @DataSource.groovy@, and @BootStrap.groovy@ files in the @grails-app/conf@ directory can use per-environment configuration using the syntax provided by "ConfigSlurper":http://groovy.codehaus.org/ConfigSlurper. As an example consider the following default @DataSource@ definition provided by Grails:
+Grails supports the concept of per environment configuration. The @Config.groovy@, @DataSource.groovy@, and @BootStrap.groovy@ files in the @grails-app/conf@ directory can use per-environment configuration using the syntax provided by [ConfigSlurper|http://groovy.codehaus.org/ConfigSlurper]. As an example consider the following default @DataSource@ definition provided by Grails:
 
 {code:java}
 dataSource {


### PR DESCRIPTION
The link to ConfigSlurper is broken. The reason is because the author
used the markup:

   "ConfigSlurper":http://groovy.codehaus.org/ConfigSlurper.

Mixing the URL with punctuation (the trailing '.',  a valid URL
character) results in the '.' being included in the generated URL -
"http://groovy.codehaus.org/ConfigSlurper."

I switched up the markup used to be an alternative link markup:

   [ConfigSlurper|http://groovy.codehaus.org/ConfigSlurper].

The result is the output the author intended.
