### PR TITLE
Documentation fix: wrong logger names

### DIFF
--- a/src/en/guide/conf/config/logging.gdoc
+++ b/src/en/guide/conf/config/logging.gdoc
@@ -61,7 +61,7 @@ class MyService {
 }
 {code}
 
-then the name of the logger will be 'grails.app.service.org.example.MyService'.
+then the name of the logger will be 'grails.app.services.org.example.MyService'.
 
 For other classes, the typical approach is to store a logger based on the class name in a constant static field:
 
@@ -231,7 +231,7 @@ Once you have declared your extra appenders, you can attach them to specific log
 error myAppender: "grails.app.controllers.BookController"
 {code}
 
-This will ensure that the 'grails.app.controller.BookController' logger sends log messages to 'myAppender' as well as any appenders configured for the root logger. To add more than one appender to the logger, then add them to the same level declaration:
+This will ensure that the 'grails.app.controllers.BookController' logger sends log messages to 'myAppender' as well as any appenders configured for the root logger. To add more than one appender to the logger, then add them to the same level declaration:
 
 {code:java}
 error myAppender:      "grails.app.controllers.BookController",
@@ -250,7 +250,7 @@ debug myFileAppender:  "grails.app.controllers.BookController"
 fatal rollingFile:     "grails.app.controllers.BookController"
 {code}
 
-you'd find that only 'fatal' level messages get logged for 'grails.app.controller.BookController'. That's because the last level declared for a given logger wins. What you probably want to do is limit what level of messages an appender writes.
+you'd find that only 'fatal' level messages get logged for 'grails.app.controllers.BookController'. That's because the last level declared for a given logger wins. What you probably want to do is limit what level of messages an appender writes.
 
 An appender that is attached to a logger configured with the 'all' level will generate a lot of logging information. That may be fine in a file, but it makes working at the console difficult. So we configure the console appender to only write out messages at 'info' level or above:
 

--- a/src/es/guide/conf/config/logging.gdoc
+++ b/src/es/guide/conf/config/logging.gdoc
@@ -120,13 +120,13 @@ class MyService {
 
 {hidden}
 
-then the name of the logger will be 'grails.app.service.org.example.MyService'.
+then the name of the logger will be 'grails.app.services.org.example.MyService'.
 
 For other classes, the typical approach is to store a logger based on the class name in a constant static field:
 
 {hidden}
 
-el nombre del logger será 'grails.app.service.org.example.MyService'.
+el nombre del logger será 'grails.app.services.org.example.MyService'.
 
 Para otras clases, el enfoque típico es almacenar un logger basado en el nombre de clase en un campo estático constante:
 
@@ -404,10 +404,10 @@ This approach can be used to configure @JMSAppender@, @SocketAppender@, @SMTPApp
 Once you have declared your extra appenders, you can attach them to specific loggers by passing the name as a key to one of the log level methods from the previous section:
 
 {code:java}
-error myAppender: "grails.app.controller.BookController"
+error myAppender: "grails.app.controllers.BookController"
 {code}
 
-This will ensure that the 'grails.app.controller.BookController' logger sends log messages to 'myAppender' as well as any appenders configured for the root logger. To add more than one appender to the logger, then add them to the same level declaration:
+This will ensure that the 'grails.app.controllers.BookController' logger sends log messages to 'myAppender' as well as any appenders configured for the root logger. To add more than one appender to the logger, then add them to the same level declaration:
 {hidden}
 
 Este enfoque puede utilizarse para configurar @JMSAppender@, @SocketAppender@, @SMTPAppender@ y muchos más.
@@ -415,16 +415,16 @@ Este enfoque puede utilizarse para configurar @JMSAppender@, @SocketAppender@, @
 Una vez que ha declarado sus appenders adicionales, puede conectarlos a loggers específicos pasando el nombre como clave a uno de los métodos de registro de niveles de la sección anterior:
 
 {code:java}
-error myAppender: "grails.app.controller.BookController"
+error myAppender: "grails.app.controllers.BookController"
 {code}
 
-Esto asegurará que el logger de 'grails.app.controller.BookController' envía mensajes de registro a 'myAppender', así como cualquier appender configurado para el logger raíz. Para agregar más de un appender al logger agreguelos a la misma declaración de nivel:
+Esto asegurará que el logger de 'grails.app.controllers.BookController' envía mensajes de registro a 'myAppender', así como cualquier appender configurado para el logger raíz. Para agregar más de un appender al logger agreguelos a la misma declaración de nivel:
 
 {code:java}
-error myAppender:      "grails.app.controller.BookController",
-      myFileAppender:  ["grails.app.controller.BookController",
-                        "grails.app.service.BookService"],
-      rollingFile:     "grails.app.controller.BookController"
+error myAppender:      "grails.app.controllers.BookController",
+      myFileAppender:  ["grails.app.controllers.BookController",
+                        "grails.app.services.BookService"],
+      rollingFile:     "grails.app.controllers.BookController"
 {code}
 
 {hidden}
@@ -437,24 +437,24 @@ El ejemplo anterior muestra cómo puede configurar más de un logger para un det
 Be aware that you can only configure a single level for a logger, so if you tried this code:
 
 {code:java}
-error myAppender:      "grails.app.controller.BookController"
-debug myFileAppender:  "grails.app.controller.BookController"
-fatal rollingFile:     "grails.app.controller.BookController"
+error myAppender:      "grails.app.controllers.BookController"
+debug myFileAppender:  "grails.app.controllers.BookController"
+fatal rollingFile:     "grails.app.controllers.BookController"
 {code}
 
-you'd find that only 'fatal' level messages get logged for 'grails.app.controller.BookController'. That's because the last level declared for a given logger wins. What you probably want to do is limit what level of messages an appender writes.
+you'd find that only 'fatal' level messages get logged for 'grails.app.controllers.BookController'. That's because the last level declared for a given logger wins. What you probably want to do is limit what level of messages an appender writes.
 
 {hidden}
 
 Tenga en cuenta que sólo se puede configurar un único nivel de un logger, así que si has probado este código:
 
 {code:java}
-error myAppender:      "grails.app.controller.BookController"
-debug myFileAppender:  "grails.app.controller.BookController"
-fatal rollingFile:     "grails.app.controller.BookController"
+error myAppender:      "grails.app.controllers.BookController"
+debug myFileAppender:  "grails.app.controllers.BookController"
+fatal rollingFile:     "grails.app.controllers.BookController"
 {code}
 
-encontrará que se registran los mensajes de niveles sólo 'fatal' para 'grails.app.controller.BookController'. Eso es porque el último nivel declarado para un logger dado es el que se asigna. Lo que probablemente desea hacer es limitar el nivel de mensajes que un appender escribe.
+encontrará que se registran los mensajes de niveles sólo 'fatal' para 'grails.app.controllers.BookController'. Eso es porque el último nivel declarado para un logger dado es el que se asigna. Lo que probablemente desea hacer es limitar el nivel de mensajes que un appender escribe.
 
 {hidden}
 
@@ -726,8 +726,8 @@ log4j = {
     }
 
     info additivity: false
-         stdout: \["grails.app.controller.BookController",
-                  "grails.app.service.BookService"\]
+         stdout: \["grails.app.controllers.BookController",
+                  "grails.app.services.BookService"\]
 }
 {code}
 
@@ -736,8 +736,8 @@ log4j = {
 So when you specify a log level, add an 'additivity' named argument. Note that you when you specify the additivity, you must configure the loggers for a named appender. The following syntax will _not_ work:
 
 {code:java}
-info additivity: false, \["grails.app.controller.BookController",
-                         "grails.app.service.BookService"\]
+info additivity: false, \["grails.app.controllers.BookController",
+                         "grails.app.services.BookService"\]
 {code}
 
 h3. Customizing stack trace printing and filtering
@@ -747,8 +747,8 @@ h3. Customizing stack trace printing and filtering
 Así que cuando se especifica un nivel de registro, agregue un argumento 'additivity'. Tenga en cuenta que cuando se especifica la 'additivity', debe configurar los loggers para un appender con nombre. La siguiente sintaxis _no_ funcionará:
 
 {code:java}
-info additivity: false, \["grails.app.controller.BookController",
-                         "grails.app.service.BookService"\]
+info additivity: false, \["grails.app.controllers.BookController",
+                         "grails.app.services.BookService"\]
 {code}
 
 h3. Personalización de impresión y filtro de stacktraces

--- a/src/fr/guide/conf/config/logging.gdoc
+++ b/src/fr/guide/conf/config/logging.gdoc
@@ -61,7 +61,7 @@ class MyService {
 }
 {code}
 
-then the name of the logger will be 'grails.app.service.org.example.MyService'.
+then the name of the logger will be 'grails.app.services.org.example.MyService'.
 
 For other classes, the typical approach is to store a logger based on the class name in a constant static field:
 
@@ -227,16 +227,16 @@ This approach can be used to configure @JMSAppender@, @SocketAppender@, @SMTPApp
 Once you have declared your extra appenders, you can attach them to specific loggers by passing the name as a key to one of the log level methods from the previous section:
 
 {code:java}
-error myAppender: "grails.app.controller.BookController"
+error myAppender: "grails.app.controllers.BookController"
 {code}
 
-This will ensure that the 'grails.app.controller.BookController' logger sends log messages to 'myAppender' as well as any appenders configured for the root logger. To add more than one appender to the logger, then add them to the same level declaration:
+This will ensure that the 'grails.app.controllers.BookController' logger sends log messages to 'myAppender' as well as any appenders configured for the root logger. To add more than one appender to the logger, then add them to the same level declaration:
 
 {code:java}
-error myAppender:      "grails.app.controller.BookController",
-      myFileAppender:  ["grails.app.controller.BookController",
-                        "grails.app.service.BookService"],
-      rollingFile:     "grails.app.controller.BookController"
+error myAppender:      "grails.app.controllers.BookController",
+      myFileAppender:  ["grails.app.controllers.BookController",
+                        "grails.app.services.BookService"],
+      rollingFile:     "grails.app.controllers.BookController"
 {code}
 
 The above example also shows how you can configure more than one logger at a time for a given appender (@myFileAppender@) by using a list.
@@ -244,12 +244,12 @@ The above example also shows how you can configure more than one logger at a tim
 Be aware that you can only configure a single level for a logger, so if you tried this code:
 
 {code:java}
-error myAppender:      "grails.app.controller.BookController"
-debug myFileAppender:  "grails.app.controller.BookController"
-fatal rollingFile:     "grails.app.controller.BookController"
+error myAppender:      "grails.app.controllers.BookController"
+debug myFileAppender:  "grails.app.controllers.BookController"
+fatal rollingFile:     "grails.app.controllers.BookController"
 {code}
 
-you'd find that only 'fatal' level messages get logged for 'grails.app.controller.BookController'. That's because the last level declared for a given logger wins. What you probably want to do is limit what level of messages an appender writes.
+you'd find that only 'fatal' level messages get logged for 'grails.app.controllers.BookController'. That's because the last level declared for a given logger wins. What you probably want to do is limit what level of messages an appender writes.
 
 An appender that is attached to a logger configured with the 'all' level will generate a lot of logging information. That may be fine in a file, but it makes working at the console difficult. So we configure the console appender to only write out messages at 'info' level or above:
 
@@ -413,16 +413,16 @@ log4j = {
     }
 
     info additivity: false
-         stdout: \["grails.app.controller.BookController",
-                  "grails.app.service.BookService"\]
+         stdout: \["grails.app.controllers.BookController",
+                  "grails.app.services.BookService"\]
 }
 {code}
 
 So when you specify a log level, add an 'additivity' named argument. Note that you when you specify the additivity, you must configure the loggers for a named appender. The following syntax will _not_ work:
 
 {code:java}
-info additivity: false, \["grails.app.controller.BookController",
-                         "grails.app.service.BookService"\]
+info additivity: false, \["grails.app.controllers.BookController",
+                         "grails.app.services.BookService"\]
 {code}
 
 h3. Customizing stack trace printing and filtering

--- a/src/pt_PT/guide/conf/config/logging.gdoc
+++ b/src/pt_PT/guide/conf/config/logging.gdoc
@@ -61,7 +61,7 @@ class MyService {
 }
 {code}
 
-then the name of the logger will be 'grails.app.service.org.example.MyService'.
+then the name of the logger will be 'grails.app.services.org.example.MyService'.
 
 For other classes, the typical approach is to store a logger based on the class name in a constant static field:
 
@@ -227,16 +227,16 @@ This approach can be used to configure @JMSAppender@, @SocketAppender@, @SMTPApp
 Once you have declared your extra appenders, you can attach them to specific loggers by passing the name as a key to one of the log level methods from the previous section:
 
 {code:java}
-error myAppender: "grails.app.controller.BookController"
+error myAppender: "grails.app.controllers.BookController"
 {code}
 
-This will ensure that the 'grails.app.controller.BookController' logger sends log messages to 'myAppender' as well as any appenders configured for the root logger. To add more than one appender to the logger, then add them to the same level declaration:
+This will ensure that the 'grails.app.controllers.BookController' logger sends log messages to 'myAppender' as well as any appenders configured for the root logger. To add more than one appender to the logger, then add them to the same level declaration:
 
 {code:java}
-error myAppender:      "grails.app.controller.BookController",
-      myFileAppender:  ["grails.app.controller.BookController",
-                        "grails.app.service.BookService"],
-      rollingFile:     "grails.app.controller.BookController"
+error myAppender:      "grails.app.controllers.BookController",
+      myFileAppender:  ["grails.app.controllers.BookController",
+                        "grails.app.services.BookService"],
+      rollingFile:     "grails.app.controllers.BookController"
 {code}
 
 The above example also shows how you can configure more than one logger at a time for a given appender (@myFileAppender@) by using a list.
@@ -244,12 +244,12 @@ The above example also shows how you can configure more than one logger at a tim
 Be aware that you can only configure a single level for a logger, so if you tried this code:
 
 {code:java}
-error myAppender:      "grails.app.controller.BookController"
-debug myFileAppender:  "grails.app.controller.BookController"
-fatal rollingFile:     "grails.app.controller.BookController"
+error myAppender:      "grails.app.controllers.BookController"
+debug myFileAppender:  "grails.app.controllers.BookController"
+fatal rollingFile:     "grails.app.controllers.BookController"
 {code}
 
-you'd find that only 'fatal' level messages get logged for 'grails.app.controller.BookController'. That's because the last level declared for a given logger wins. What you probably want to do is limit what level of messages an appender writes.
+you'd find that only 'fatal' level messages get logged for 'grails.app.controllers.BookController'. That's because the last level declared for a given logger wins. What you probably want to do is limit what level of messages an appender writes.
 
 An appender that is attached to a logger configured with the 'all' level will generate a lot of logging information. That may be fine in a file, but it makes working at the console difficult. So we configure the console appender to only write out messages at 'info' level or above:
 
@@ -413,16 +413,16 @@ log4j = {
     }
 
     info additivity: false
-         stdout: \["grails.app.controller.BookController",
-                  "grails.app.service.BookService"\]
+         stdout: \["grails.app.controllers.BookController",
+                  "grails.app.services.BookService"\]
 }
 {code}
 
 So when you specify a log level, add an 'additivity' named argument. Note that you when you specify the additivity, you must configure the loggers for a named appender. The following syntax will _not_ work:
 
 {code:java}
-info additivity: false, \["grails.app.controller.BookController",
-                         "grails.app.service.BookService"\]
+info additivity: false, \["grails.app.controllers.BookController",
+                         "grails.app.services.BookService"\]
 {code}
 
 h3. Customizing stack trace printing and filtering

--- a/src/th/guide/conf/config/logging.gdoc
+++ b/src/th/guide/conf/config/logging.gdoc
@@ -61,7 +61,7 @@ class MyService {
 }
 {code}
 
-then the name of the logger will be 'grails.app.service.org.example.MyService'.
+then the name of the logger will be 'grails.app.services.org.example.MyService'.
 
 For other classes, the typical approach is to store a logger based on the class name in a constant static field:
 
@@ -227,16 +227,16 @@ This approach can be used to configure @JMSAppender@, @SocketAppender@, @SMTPApp
 Once you have declared your extra appenders, you can attach them to specific loggers by passing the name as a key to one of the log level methods from the previous section:
 
 {code:java}
-error myAppender: "grails.app.controller.BookController"
+error myAppender: "grails.app.controllers.BookController"
 {code}
 
-This will ensure that the 'grails.app.controller.BookController' logger sends log messages to 'myAppender' as well as any appenders configured for the root logger. To add more than one appender to the logger, then add them to the same level declaration:
+This will ensure that the 'grails.app.controllers.BookController' logger sends log messages to 'myAppender' as well as any appenders configured for the root logger. To add more than one appender to the logger, then add them to the same level declaration:
 
 {code:java}
-error myAppender:      "grails.app.controller.BookController",
-      myFileAppender:  ["grails.app.controller.BookController",
-                        "grails.app.service.BookService"],
-      rollingFile:     "grails.app.controller.BookController"
+error myAppender:      "grails.app.controllers.BookController",
+      myFileAppender:  ["grails.app.controllers.BookController",
+                        "grails.app.services.BookService"],
+      rollingFile:     "grails.app.controllers.BookController"
 {code}
 
 The above example also shows how you can configure more than one logger at a time for a given appender (@myFileAppender@) by using a list.
@@ -244,12 +244,12 @@ The above example also shows how you can configure more than one logger at a tim
 Be aware that you can only configure a single level for a logger, so if you tried this code:
 
 {code:java}
-error myAppender:      "grails.app.controller.BookController"
-debug myFileAppender:  "grails.app.controller.BookController"
-fatal rollingFile:     "grails.app.controller.BookController"
+error myAppender:      "grails.app.controllers.BookController"
+debug myFileAppender:  "grails.app.controllers.BookController"
+fatal rollingFile:     "grails.app.controllers.BookController"
 {code}
 
-you'd find that only 'fatal' level messages get logged for 'grails.app.controller.BookController'. That's because the last level declared for a given logger wins. What you probably want to do is limit what level of messages an appender writes.
+you'd find that only 'fatal' level messages get logged for 'grails.app.controllers.BookController'. That's because the last level declared for a given logger wins. What you probably want to do is limit what level of messages an appender writes.
 
 An appender that is attached to a logger configured with the 'all' level will generate a lot of logging information. That may be fine in a file, but it makes working at the console difficult. So we configure the console appender to only write out messages at 'info' level or above:
 
@@ -413,16 +413,16 @@ log4j = {
     }
 
     info additivity: false
-         stdout: \["grails.app.controller.BookController",
-                  "grails.app.service.BookService"\]
+         stdout: \["grails.app.controllers.BookController",
+                  "grails.app.services.BookService"\]
 }
 {code}
 
 So when you specify a log level, add an 'additivity' named argument. Note that you when you specify the additivity, you must configure the loggers for a named appender. The following syntax will _not_ work:
 
 {code:java}
-info additivity: false, \["grails.app.controller.BookController",
-                         "grails.app.service.BookService"\]
+info additivity: false, \["grails.app.controllers.BookController",
+                         "grails.app.services.BookService"\]
 {code}
 
 h3. Customizing stack trace printing and filtering

--- a/src/zh_CN/guide/conf/config/logging.gdoc
+++ b/src/zh_CN/guide/conf/config/logging.gdoc
@@ -108,7 +108,7 @@ class MyService {
 }
 {code}
 
-then the name of the logger will be 'grails.app.service.org.example.MyService'.
+then the name of the logger will be 'grails.app.services.org.example.MyService'.
 
 For other classes, the typical approach is to store a logger based on the class name in a constant static field:
 
@@ -147,7 +147,7 @@ class MyService {
 }
 {code}
 
-那么上述记录器的名字是'grails.app.service.org.example.MyService'。
+那么上述记录器的名字是'grails.app.services.org.example.MyService'。
 
 对其他类来说，典型的方法是将记录器作为此类的一个静态常量字段，比如：
 
@@ -415,16 +415,16 @@ This approach can be used to configure @JMSAppender@, @SocketAppender@, @SMTPApp
 Once you have declared your extra appenders, you can attach them to specific loggers by passing the name as a key to one of the log level methods from the previous section:
 
 {code:java}
-error myAppender: "grails.app.controller.BookController"
+error myAppender: "grails.app.controllers.BookController"
 {code}
 
-This will ensure that the 'grails.app.controller.BookController' logger sends log messages to 'myAppender' as well as any appenders configured for the root logger. To add more than one appender to the logger, then add them to the same level declaration:
+This will ensure that the 'grails.app.controllers.BookController' logger sends log messages to 'myAppender' as well as any appenders configured for the root logger. To add more than one appender to the logger, then add them to the same level declaration:
 
 {code:java}
-error myAppender:      "grails.app.controller.BookController",
-      myFileAppender:  ["grails.app.controller.BookController",
-                        "grails.app.service.BookService"],
-      rollingFile:     "grails.app.controller.BookController"
+error myAppender:      "grails.app.controllers.BookController",
+      myFileAppender:  ["grails.app.controllers.BookController",
+                        "grails.app.services.BookService"],
+      rollingFile:     "grails.app.controllers.BookController"
 {code}
 
 The above example also shows how you can configure more than one logger at a time for a given appender (@myFileAppender@) by using a list.
@@ -432,12 +432,12 @@ The above example also shows how you can configure more than one logger at a tim
 Be aware that you can only configure a single level for a logger, so if you tried this code:
 
 {code:java}
-error myAppender:      "grails.app.controller.BookController"
-debug myFileAppender:  "grails.app.controller.BookController"
-fatal rollingFile:     "grails.app.controller.BookController"
+error myAppender:      "grails.app.controllers.BookController"
+debug myFileAppender:  "grails.app.controllers.BookController"
+fatal rollingFile:     "grails.app.controllers.BookController"
 {code}
 
-you'd find that only 'fatal' level messages get logged for 'grails.app.controller.BookController'. That's because the last level declared for a given logger wins. What you probably want to do is limit what level of messages an appender writes.
+you'd find that only 'fatal' level messages get logged for 'grails.app.controllers.BookController'. That's because the last level declared for a given logger wins. What you probably want to do is limit what level of messages an appender writes.
 
 An appender that is attached to a logger configured with the 'all' level will generate a lot of logging information. That may be fine in a file, but it makes working at the console difficult. So we configure the console appender to only write out messages at 'info' level or above:
 
@@ -506,16 +506,16 @@ log4j = {
 一旦你声明了这些额外的输出器，那么你还需要将它们跟特定的记录器进行关联，这可以通过记录器的名称和记录级别来完成，比如：
 
 {code:java}
-error myAppender: "grails.app.controller.BookController"
+error myAppender: "grails.app.controllers.BookController"
 {code}
 
-这样就可以保证记录器'grails.app.controller.BookController'将消息发送到'myAppender'中以及配置在根记录器中的任何输出器，要在记录器中增加更多的输出器，只需要将他们加入到同级别的声明即可，比如：
+这样就可以保证记录器'grails.app.controllers.BookController'将消息发送到'myAppender'中以及配置在根记录器中的任何输出器，要在记录器中增加更多的输出器，只需要将他们加入到同级别的声明即可，比如：
 
 {code:java}
-error myAppender:      "grails.app.controller.BookController",
-      myFileAppender:  ["grails.app.controller.BookController",
-                        "grails.app.service.BookService"],
-      rollingFile:     "grails.app.controller.BookController"
+error myAppender:      "grails.app.controllers.BookController",
+      myFileAppender:  ["grails.app.controllers.BookController",
+                        "grails.app.services.BookService"],
+      rollingFile:     "grails.app.controllers.BookController"
 {code}
 
 上述示例同时也展示了在一个给定的输出器(@myFileAppender@)中如何通过列表来配置多个记录器。
@@ -523,12 +523,12 @@ error myAppender:      "grails.app.controller.BookController",
 需要注意的是：一个记录器只能配置一个级别，如果你配置了如下的内容：
 
 {code:java}
-error myAppender:      "grails.app.controller.BookController"
-debug myFileAppender:  "grails.app.controller.BookController"
-fatal rollingFile:     "grails.app.controller.BookController"
+error myAppender:      "grails.app.controllers.BookController"
+debug myFileAppender:  "grails.app.controllers.BookController"
+fatal rollingFile:     "grails.app.controllers.BookController"
 {code}
 
-你将会发现'grails.app.controller.BookController'记录器只记录'fatal'级别的消息，这是因为最后的级别设置将以前的覆盖掉了。你这样做的意图是想限制输出器的级别。
+你将会发现'grails.app.controllers.BookController'记录器只记录'fatal'级别的消息，这是因为最后的级别设置将以前的覆盖掉了。你这样做的意图是想限制输出器的级别。
 
 一个根'all'级别记录器关联的输出器将记录大量的日志信息，如果记录在文件中，也许还能忍受，但在字符终端完全是另外一回事。因此我们需要将字符终端的输出器只记录'info'及其级别以上内容：
 
@@ -805,16 +805,16 @@ log4j = {
     }
 
     info additivity: false
-         stdout: \["grails.app.controller.BookController",
-                  "grails.app.service.BookService"\]
+         stdout: \["grails.app.controllers.BookController",
+                  "grails.app.services.BookService"\]
 }
 {code}
 
 So when you specify a log level, add an 'additivity' named argument. Note that you when you specify the additivity, you must configure the loggers for a named appender. The following syntax will _not_ work:
 
 {code:java}
-info additivity: false, \["grails.app.controller.BookController",
-                         "grails.app.service.BookService"\]
+info additivity: false, \["grails.app.controllers.BookController",
+                         "grails.app.services.BookService"\]
 {code}
 
 h3. Customizing stack trace printing and filtering

--- a/src/zh_TW/guide/conf/config/logging.gdoc
+++ b/src/zh_TW/guide/conf/config/logging.gdoc
@@ -61,7 +61,7 @@ class MyService {
 }
 {code}
 
-then the name of the logger will be 'grails.app.service.org.example.MyService'.
+then the name of the logger will be 'grails.app.services.org.example.MyService'.
 
 For other classes, the typical approach is to store a logger based on the class name in a constant static field:
 
@@ -228,16 +228,16 @@ This approach can be used to configure @JMSAppender@, @SocketAppender@, @SMTPApp
 Once you have declared your extra appenders, you can attach them to specific loggers by passing the name as a key to one of the log level methods from the previous section:
 
 {code:java}
-error myAppender: "grails.app.controller.BookController"
+error myAppender: "grails.app.controllers.BookController"
 {code}
 
-This will ensure that the 'grails.app.controller.BookController' logger sends log messages to 'myAppender' as well as any appenders configured for the root logger. To add more than one appender to the logger, then add them to the same level declaration:
+This will ensure that the 'grails.app.controllers.BookController' logger sends log messages to 'myAppender' as well as any appenders configured for the root logger. To add more than one appender to the logger, then add them to the same level declaration:
 
 {code:java}
-error myAppender:      "grails.app.controller.BookController",
-      myFileAppender:  ["grails.app.controller.BookController",
-                        "grails.app.service.BookService"],
-      rollingFile:     "grails.app.controller.BookController"
+error myAppender:      "grails.app.controllers.BookController",
+      myFileAppender:  ["grails.app.controllers.BookController",
+                        "grails.app.services.BookService"],
+      rollingFile:     "grails.app.controllers.BookController"
 {code}
 
 The above example also shows how you can configure more than one logger at a time for a given appender (@myFileAppender@) by using a list.
@@ -245,12 +245,12 @@ The above example also shows how you can configure more than one logger at a tim
 Be aware that you can only configure a single level for a logger, so if you tried this code:
 
 {code:java}
-error myAppender:      "grails.app.controller.BookController"
-debug myFileAppender:  "grails.app.controller.BookController"
-fatal rollingFile:     "grails.app.controller.BookController"
+error myAppender:      "grails.app.controllers.BookController"
+debug myFileAppender:  "grails.app.controllers.BookController"
+fatal rollingFile:     "grails.app.controllers.BookController"
 {code}
 
-you'd find that only 'fatal' level messages get logged for 'grails.app.controller.BookController'. That's because the last level declared for a given logger wins. What you probably want to do is limit what level of messages an appender writes.
+you'd find that only 'fatal' level messages get logged for 'grails.app.controllers.BookController'. That's because the last level declared for a given logger wins. What you probably want to do is limit what level of messages an appender writes.
 
 An appender that is attached to a logger configured with the 'all' level will generate a lot of logging information. That may be fine in a file, but it makes working at the console difficult. So we configure the console appender to only write out messages at 'info' level or above:
 
@@ -414,16 +414,16 @@ log4j = {
     }
 
     info additivity: false
-         stdout: \["grails.app.controller.BookController",
-                  "grails.app.service.BookService"\]
+         stdout: \["grails.app.controllers.BookController",
+                  "grails.app.services.BookService"\]
 }
 {code}
 
 So when you specify a log level, add an 'additivity' named argument. Note that you when you specify the additivity, you must configure the loggers for a named appender. The following syntax will _not_ work:
 
 {code:java}
-info additivity: false, \["grails.app.controller.BookController",
-                         "grails.app.service.BookService"\]
+info additivity: false, \["grails.app.controllers.BookController",
+                         "grails.app.services.BookService"\]
 {code}
 
 h3. Customizing stack trace printing and filtering


### PR DESCRIPTION
logger names are constructed using "controllers" and "services" instead of
"controller" and "service"

Fixes GRAILS-8836
