### PR TITLE
The "type" used by the injected logger is plural

### DIFF
--- a/src/en/guide/conf/config/logging.gdoc
+++ b/src/en/guide/conf/config/logging.gdoc
@@ -51,7 +51,7 @@ There are two main ways to get hold of a logger:
 # use the @log@ instance injected into artifacts such as domain classes, controllers and services;
 # use the Commons Logging API directly.
 
-If you use the dynamic @log@ property, then the name of the logger is 'grails.app.<type>.<className>', where @type@ is the type of the artifact, for example 'controller' or 'service, and @className@ is the fully qualified name of the artifact. For example, if you have this service:
+If you use the dynamic @log@ property, then the name of the logger is 'grails.app.<type>.<className>', where @type@ is the type of the artifact, for example 'controllers' or 'services', and @className@ is the fully qualified name of the artifact. For example, if you have this service:
 
 {code:java}
 package org.example


### PR DESCRIPTION
Where the logger name is first defined, type is singular, the example below correctly uses the plural.
