### PR TITLE
Added example to showcase the model parameter of applyTemplate

### DIFF
--- a/src/en/guide/testing/unitTesting/unitTestingTagLibraries.gdoc
+++ b/src/en/guide/testing/unitTesting/unitTestingTagLibraries.gdoc
@@ -31,6 +31,10 @@ class SimpleTagLib {
     def hello = { attrs, body ->
         out << "Hello ${attrs.name ?: 'World'}"
     }
+    
+    def bye = { attrs, body ->
+        out << "Bye ${attrs.author.name ?: 'World'}"
+    }
 }
 {code}
 
@@ -42,6 +46,7 @@ class SimpleTagLibTests {
     void testHelloTag() {
         assert applyTemplate('<s:hello />') == 'Hello World'
         assert applyTemplate('<s:hello name="Fred" />') == 'Hello Fred'
+        assert applyTemplate('<s:bye author="${author}" />', [author: new Author(name: 'Fred')]) == 'Bye Fred'
     }
 }
 {code}


### PR DESCRIPTION
The section "Testing Custom Tags" did not mention the second parameter you can pass to applyTemplate. Therefore I have added a short, hopefully self-explanatory example.
