### PR TITLE
Fix link to iBatis. 1) Comma was treated as part of the URL, use alterna...

### DIFF
--- a/src/en/guide/GORM/persistenceBasics.gdoc
+++ b/src/en/guide/GORM/persistenceBasics.gdoc
@@ -1,4 +1,4 @@
-A key thing to remember about Grails is that under the surface Grails is using "Hibernate":http://www.hibernate.org/ for persistence. If you are coming from a background of using "ActiveRecord":http://wiki.rubyonrails.org/rails/pages/ActiveRecord or "iBatis":http://ibatis.apache.org/, Hibernate's "session" model may feel a little strange.
+A key thing to remember about Grails is that under the surface Grails is using "Hibernate":http://www.hibernate.org/ for persistence. If you are coming from a background of using "ActiveRecord":http://wiki.rubyonrails.org/rails/pages/ActiveRecord or [iBatis/MyBatis|http://www.mybatis.org/], Hibernate's "session" model may feel a little strange.
 
 Grails automatically binds a Hibernate session to the currently executing request. This lets you use the [save|domainClasses] and [delete|domainClasses] methods as well as other GORM methods transparently.
 


### PR DESCRIPTION
...tive link syntax so that the link will work. 2) iBatis has moved and changed name to MyBatis.
