### PR TITLE
Fix for wrapper script documentation

### DIFF
--- a/src/en/guide/commandLine/wrapper.gdoc
+++ b/src/en/guide/commandLine/wrapper.gdoc
@@ -16,7 +16,7 @@ By default the wrapper command will generate a @grailsw@ shell script and @grail
 
 h4. Using The Wrapper
 
-The wrapper scripts except all of the same arguments the normal grails command supports.
+The wrapper script accepts all of the same arguments as the normal grails command.
 
 {code}
 ./grailsw create-domain-class com.demo.Person


### PR DESCRIPTION
The wrapper script documentation uses 'except' instead of 'accept'.  Also made the phrasing of that sentence slightly less awkward.
