### PR TITLE
GRAILS-8960 - Wrong relative image link

### DIFF
--- a/src/en/ref/Command Line/console.gdoc
+++ b/src/en/ref/Command Line/console.gdoc
@@ -27,7 +27,3 @@ grails [environment]* console
 Fired Events:
 
 * @StatusFinal@ - When the console is loaded
-
-Screenshot:
-
-!console.png!


### PR DESCRIPTION
Removed the image as I think it isn't needed anyway.
