### PR TITLE
GRAILS-7733 - documentation for "value" parameter

### DIFF
--- a/src/en/ref/Tags/submitToRemote.gdoc
+++ b/src/en/ref/Tags/submitToRemote.gdoc
@@ -26,7 +26,7 @@ Example usages for above controller:
 {code:xml}
 <g:form action="show">
     Login: <input name="login" type="text" />
-    <g:submitToRemote update="updateMe" />
+    <g:submitToRemote url="[action: 'show']" update="updateMe" />
 </g:form>
 
 <div id="updateMe">this div will be updated with the form submit response</div>
@@ -39,6 +39,7 @@ This tag creates a submit button that fires an AJAX request when it is pressed. 
 Attributes
 
 * @url@ - The url to submit to, either a map contraining keys for the action, controller and id or a string value
+* @value@ (optional) - The title of the button
 * @update@ (optional) - Either a Map containing the elements to update for 'success' or 'failure' states, or a string with the element id to update, in which case failure events would be ignored
 * @before@ (optional) - The JavaScript function to call before the remote function call. A semi-colon is automatically added so you don't have to provide one yourself in this string.
 * @after@ (optional) - The JavaScript function to call after the remote function call. A semi-colon is automatically added so you don't have to provide one yourself in this string.


### PR DESCRIPTION
- Adds documentation for value attribute
- Fixes example, the tag requires the url attribute with at least
    the action key set or it won't work, tested with Grails 2.2.0.
