### PR TITLE
GRAILS-6130 - capital letters in plugin name

### DIFF
--- a/src/en/guide/plugins/creatingAndInstallingPlugins.gdoc
+++ b/src/en/guide/plugins/creatingAndInstallingPlugins.gdoc
@@ -8,6 +8,8 @@ grails create-plugin [PLUGIN NAME]
 
 This will create a plugin project for the name you specify. For example running @grails create-plugin example@ would create a new plugin project called @example@.
 
+Make sure the plugin name does not contain more than one capital in a row, or it won't work. Camel case is fine, though.
+
 The structure of a Grails plugin is very nearly the same as a Grails application project's except that in the root of the plugin directory you will find a plugin Groovy file called the "plugin descriptor".
 
 {note}


### PR DESCRIPTION
A plugin may not have more than one capital letter in a row
in it's name, this is now mentioned in the docs.
