### PR TITLE
Add --update-data-source flag to the description of the upgrade command

### DIFF
--- a/src/en/ref/Command Line/upgrade.gdoc
+++ b/src/en/ref/Command Line/upgrade.gdoc
@@ -8,6 +8,7 @@ h2. Examples
 
 {code:java}
 grails upgrade
+grails upgrade --update-data-source
 {code}
 
 h2. Description
@@ -16,6 +17,11 @@ Usage:
 {code:java}
 grails upgrade
 {code}
+
+Arguments:
+
+* @update-data-source@ - upgrades DataSource.groovy to use H2 instead of HSQLDB.
+
 
 Fired Events:
 


### PR DESCRIPTION
The --update-data-source flag is not documented in the upgrade command.
