### PR TITLE
Fix custom foreign key column names

### DIFF
--- a/src/en/guide/GORM/advancedGORMFeatures/ormdsl/compositePrimaryKeys.gdoc
+++ b/src/en/guide/GORM/advancedGORMFeatures/ormdsl/compositePrimaryKeys.gdoc
@@ -54,9 +54,11 @@ In this case the @address@ table will have an additional two columns called @per
 class Address {
     Person person
     static mapping = {
-        person {
-            column: "FirstName"
-            column: "LastName"
+        columns {
+		    person {
+                column name: "FirstName"
+                column name: "LastName"
+			}
         }
     }
 }

--- a/src/es/guide/GORM/advancedGORMFeatures/ormdsl/compositePrimaryKeys.gdoc
+++ b/src/es/guide/GORM/advancedGORMFeatures/ormdsl/compositePrimaryKeys.gdoc
@@ -54,9 +54,11 @@ In this case the @address@ table will have an additional two columns called @per
 class Address {
     Person person
     static mapping = {
-        person {
-            column: "FirstName"
-            column: "LastName"
+        columns {
+		    person {
+                column name: "FirstName"
+                column name: "LastName"
+			}
         }
     }
 }

--- a/src/fr/guide/GORM/advancedGORMFeatures/ormdsl/compositePrimaryKeys.gdoc
+++ b/src/fr/guide/GORM/advancedGORMFeatures/ormdsl/compositePrimaryKeys.gdoc
@@ -54,9 +54,11 @@ In this case the @address@ table will have an additional two columns called @per
 class Address {
     Person person
     static mapping = {
-        person {
-            column: "FirstName"
-            column: "LastName"
+        columns {
+		    person {
+                column name: "FirstName"
+                column name: "LastName"
+			}
         }
     }
 }

--- a/src/pt_PT/guide/GORM/advancedGORMFeatures/ormdsl/compositePrimaryKeys.gdoc
+++ b/src/pt_PT/guide/GORM/advancedGORMFeatures/ormdsl/compositePrimaryKeys.gdoc
@@ -54,9 +54,11 @@ In this case the @address@ table will have an additional two columns called @per
 class Address {
     Person person
     static mapping = {
-        person {
-            column: "FirstName"
-            column: "LastName"
+        columns {
+		    person {
+                column name: "FirstName"
+                column name: "LastName"
+			}
         }
     }
 }

--- a/src/th/guide/GORM/advancedGORMFeatures/ormdsl/compositePrimaryKeys.gdoc
+++ b/src/th/guide/GORM/advancedGORMFeatures/ormdsl/compositePrimaryKeys.gdoc
@@ -54,9 +54,11 @@ In this case the @address@ table will have an additional two columns called @per
 class Address {
     Person person
     static mapping = {
-        person {
-            column: "FirstName"
-            column: "LastName"
+        columns {
+		    person {
+                column name: "FirstName"
+                column name: "LastName"
+			}
         }
     }
 }

--- a/src/zh_CN/guide/GORM/advancedGORMFeatures/ormdsl/compositePrimaryKeys.gdoc
+++ b/src/zh_CN/guide/GORM/advancedGORMFeatures/ormdsl/compositePrimaryKeys.gdoc
@@ -54,9 +54,11 @@ In this case the @address@ table will have an additional two columns called @per
 class Address {
     Person person
     static mapping = {
-        person {
-            column: "FirstName"
-            column: "LastName"
+        columns {
+		    person {
+                column name: "FirstName"
+                column name: "LastName"
+			}
         }
     }
 }

--- a/src/zh_TW/guide/GORM/advancedGORMFeatures/ormdsl/compositePrimaryKeys.gdoc
+++ b/src/zh_TW/guide/GORM/advancedGORMFeatures/ormdsl/compositePrimaryKeys.gdoc
@@ -54,9 +54,11 @@ In this case the @address@ table will have an additional two columns called @per
 class Address {
     Person person
     static mapping = {
-        person {
-            column: "FirstName"
-            column: "LastName"
+        columns {
+		    person {
+                column name: "FirstName"
+                column name: "LastName"
+			}
         }
     }
 }


### PR DESCRIPTION
Fixed the example of renaming the column names of a composite foreign
key. The person block outside columns is a invalid mapping.
