### PR TITLE
claiming to show show.gsp on action list 

### DIFF
--- a/src/en/guide/theWebLayer/controllers/modelsAndViews.gdoc
+++ b/src/en/guide/theWebLayer/controllers/modelsAndViews.gdoc
@@ -56,7 +56,7 @@ Currently, no error will be reported if you do use them, but this will hopefully
 
 h4. Selecting the View
 
-In both of the previous two examples there was no code that specified which [view|guide:gsp] to render. So how does Grails know which one to pick? The answer lies in the conventions. Grails will look for a view at the location @grails-app/views/book/show.gsp@ for this @list@ action:
+In both of the previous two examples there was no code that specified which [view|guide:gsp] to render. So how does Grails know which one to pick? The answer lies in the conventions. Grails will look for a view at the location @grails-app/views/book/show.gsp@ for this @show@ action:
 
 {code:java}
 class BookController {

--- a/src/es/guide/theWebLayer/controllers/modelsAndViews.gdoc
+++ b/src/es/guide/theWebLayer/controllers/modelsAndViews.gdoc
@@ -56,7 +56,7 @@ Currently, no error will be reported if you do use them, but this will hopefully
 
 h4. Selecting the View
 
-In both of the previous two examples there was no code that specified which [view|guide:gsp] to render. So how does Grails know which one to pick? The answer lies in the conventions. Grails will look for a view at the location @grails-app/views/book/show.gsp@ for this @list@ action:
+In both of the previous two examples there was no code that specified which [view|guide:gsp] to render. So how does Grails know which one to pick? The answer lies in the conventions. Grails will look for a view at the location @grails-app/views/book/show.gsp@ for this @show@ action:
 
 {code:java}
 class BookController {

--- a/src/fr/guide/theWebLayer/controllers/modelsAndViews.gdoc
+++ b/src/fr/guide/theWebLayer/controllers/modelsAndViews.gdoc
@@ -56,7 +56,7 @@ Currently, no error will be reported if you do use them, but this will hopefully
 
 h4. Selecting the View
 
-In both of the previous two examples there was no code that specified which [view|guide:gsp] to render. So how does Grails know which one to pick? The answer lies in the conventions. Grails will look for a view at the location @grails-app/views/book/show.gsp@ for this @list@ action:
+In both of the previous two examples there was no code that specified which [view|guide:gsp] to render. So how does Grails know which one to pick? The answer lies in the conventions. Grails will look for a view at the location @grails-app/views/book/show.gsp@ for this @show@ action:
 
 {code:java}
 class BookController {

--- a/src/pt_PT/guide/theWebLayer/controllers/modelsAndViews.gdoc
+++ b/src/pt_PT/guide/theWebLayer/controllers/modelsAndViews.gdoc
@@ -56,7 +56,7 @@ Currently, no error will be reported if you do use them, but this will hopefully
 
 h4. Selecting the View
 
-In both of the previous two examples there was no code that specified which [view|guide:gsp] to render. So how does Grails know which one to pick? The answer lies in the conventions. Grails will look for a view at the location @grails-app/views/book/show.gsp@ for this @list@ action:
+In both of the previous two examples there was no code that specified which [view|guide:gsp] to render. So how does Grails know which one to pick? The answer lies in the conventions. Grails will look for a view at the location @grails-app/views/book/show.gsp@ for this @show@ action:
 
 {code:java}
 class BookController {

--- a/src/th/guide/theWebLayer/controllers/modelsAndViews.gdoc
+++ b/src/th/guide/theWebLayer/controllers/modelsAndViews.gdoc
@@ -56,7 +56,7 @@ Currently, no error will be reported if you do use them, but this will hopefully
 
 h4. Selecting the View
 
-In both of the previous two examples there was no code that specified which [view|guide:gsp] to render. So how does Grails know which one to pick? The answer lies in the conventions. Grails will look for a view at the location @grails-app/views/book/show.gsp@ for this @list@ action:
+In both of the previous two examples there was no code that specified which [view|guide:gsp] to render. So how does Grails know which one to pick? The answer lies in the conventions. Grails will look for a view at the location @grails-app/views/book/show.gsp@ for this @show@ action:
 
 {code:java}
 class BookController {

--- a/src/zh_CN/guide/theWebLayer/controllers/modelsAndViews.gdoc
+++ b/src/zh_CN/guide/theWebLayer/controllers/modelsAndViews.gdoc
@@ -56,7 +56,7 @@ Currently, no error will be reported if you do use them, but this will hopefully
 
 h4. Selecting the View
 
-In both of the previous two examples there was no code that specified which [view|guide:gsp] to render. So how does Grails know which one to pick? The answer lies in the conventions. Grails will look for a view at the location @grails-app/views/book/show.gsp@ for this @list@ action:
+In both of the previous two examples there was no code that specified which [view|guide:gsp] to render. So how does Grails know which one to pick? The answer lies in the conventions. Grails will look for a view at the location @grails-app/views/book/show.gsp@ for this @show@ action:
 
 {code:java}
 class BookController {

--- a/src/zh_TW/guide/theWebLayer/controllers/modelsAndViews.gdoc
+++ b/src/zh_TW/guide/theWebLayer/controllers/modelsAndViews.gdoc
@@ -56,7 +56,7 @@ Currently, no error will be reported if you do use them, but this will hopefully
 
 h4. Selecting the View
 
-In both of the previous two examples there was no code that specified which [view|guide:gsp] to render. So how does Grails know which one to pick? The answer lies in the conventions. Grails will look for a view at the location @grails-app/views/book/show.gsp@ for this @list@ action:
+In both of the previous two examples there was no code that specified which [view|guide:gsp] to render. So how does Grails know which one to pick? The answer lies in the conventions. Grails will look for a view at the location @grails-app/views/book/show.gsp@ for this @show@ action:
 
 {code:java}
 class BookController {


### PR DESCRIPTION
Fixed wrong doc, claiming to show show.gsp on action list 

See: 
http://grails.org/doc/2.2.1/guide/single.html#modelsAndViews
### Selecting the View

In both of the previous two examples there was no code that specified which view to render. So how does Grails know which one to pick? The answer lies in the conventions. Grails will look for a view at the location grails-app/views/book/show.gsp for this list action:

`class BookController {
    def show() {
         [book: Book.get(params.id)]
    }
}`
