### PR TITLE
Fix link to Grails API doc

### DIFF
--- a/resources/doc.properties
+++ b/resources/doc.properties
@@ -90,6 +90,8 @@ api.org.springframework=http://static.springsource.org/spring/docs/3.0.x/javadoc
 api.javax.servlet=http://download.oracle.com/javaee/1.4/api
 api.java.=http://download.oracle.com/javase/1.5.0/docs/api
 api.groovy.lang.=http://groovy.codehaus.org/api
+api.org.codehaus.groovy.grails=http://grails.org/doc/latest/api
+api.grails.=http://grails.org/doc/latest/api
 
 # Regular expression to parse out source code
 source.tag.regex=/\s*?def\s+?[a-zA-Z]+?\s*?=\s*?\{\s*?attrs\s*?,{0,1}\s*?body{0,1}\s*?->.+?/


### PR DESCRIPTION
Cannot create link to Grails API doc.
I added settings to doc.properties.
