### PR TITLE
Fixed example for Unite testing controllers, Duplicate form submission

### DIFF
--- a/src/en/guide/testing/unitTesting/unitTestingControllers.gdoc
+++ b/src/en/guide/testing/unitTesting/unitTestingControllers.gdoc
@@ -412,8 +412,10 @@ import org.codehaus.groovy.grails.web.servlet.mvc.SynchronizerToken
 ...
 
 void testValidFormSubmission() {
-    def token = SynchronizerToken.store(session)
-    params[SynchronizerToken.KEY] = token.currentToken.toString()
+    def tokenHolder = SynchronizerTokensHolder.store(session)
+
+    params[SynchronizerTokensHolder.TOKEN_URI] = '/controller/handleForm'
+    params[SynchronizerTokensHolder.TOKEN_KEY] = tokenHolder.generateToken(params[SynchronizerTokensHolder.TOKEN_URI])
 
     controller.handleForm()
     assert "Good" == response.text


### PR DESCRIPTION
There is outdated example in the Unit testing section, that is no longer valid for Grails versions 2.x.

I've changed the small code sample to reflect new Grails.
More details on that are on my old blog post: http://greggigon.com/2012/03/23/unit-testing-grails-controllers-with-duplicate-form-submission-check-functionality
