### PR TITLE
GRAILS-6512: Specify the difference between integration and functional testing phases

### DIFF
--- a/src/en/guide/testing/functionalTesting.gdoc
+++ b/src/en/guide/testing/functionalTesting.gdoc
@@ -1,4 +1,6 @@
-Functional tests involve making HTTP requests against the running application and verifying the resultant behaviour. Grails does not ship with any support for writing functional tests directly, but there are several plugins available for this.
+Functional tests involve making HTTP requests against the running application and verifying the resultant behaviour. The functional testing phase differs from the integration phase in that the Grails application is now listening and responding to actual HTTP requests. This is useful for end-to-end testing scenarios, such as making REST calls against a JSON API.
+
+Grails does not ship with any support for writing functional tests directly, but there are several plugins available for this.
 
 * @Canoo Webtest@ - "http://grails.org/plugin/webtest":http://grails.org/plugin/webtest
 * @G-Func@ - "http://grails.org/plugin/functional-test":http://grails.org/plugin/functional-test


### PR DESCRIPTION
Make the usefulness of 'functional' testing phase a bit more apparent in the documentation.
