### PR TITLE
fixed the annotation name: 'BindUsing' -> 'BindingFormat'

### DIFF
--- a/src/en/guide/theWebLayer/controllers/dataBinding.gdoc
+++ b/src/en/guide/theWebLayer/controllers/dataBinding.gdoc
@@ -601,7 +601,7 @@ beans = {
 }
 {code}
 
-With that in place the BindUsing annotation may be applied to String fields to inform the data binder to take advantage of the custom converter.
+With that in place the @BindingFormat@ annotation may be applied to String fields to inform the data binder to take advantage of the custom converter.
 
 {code:java}
 import org.grails.databinding.BindingFormat


### PR DESCRIPTION
I think that the 'BindingUsing' here should be 'BindingFormat' because the latter is used at the following example.
