### PR TITLE
Fix invalid JSON in XML/JSON rendering section.

### DIFF
--- a/src/en/guide/theWebLayer/controllers/xmlAndJSON.gdoc
+++ b/src/en/guide/theWebLayer/controllers/xmlAndJSON.gdoc
@@ -70,8 +70,8 @@ In this case the result would be something along the lines of:
 
 {code}
 [
-    {title:"The Stand"},
-    {title:"The Shining"}
+    {"title":"The Stand"},
+    {"title":"The Shining"}
 ]
 {code}
 


### PR DESCRIPTION
The first example of rendered JSON in the section on rendering responses as XML/JSON lacks quotation marks around the keys, which are required for JSON.
