### PR TITLE
replaced 'closure' with 'method' for events

### DIFF
--- a/src/en/guide/GORM/advancedGORMFeatures/eventsAutoTimestamping.gdoc
+++ b/src/en/guide/GORM/advancedGORMFeatures/eventsAutoTimestamping.gdoc
@@ -9,7 +9,7 @@ GORM supports the registration of events as methods that get fired when certain 
 * @afterDelete@ - Executed after an object has been deleted
 * @onLoad@ - Executed when an object is loaded from the database
 
-To add an event simply register the relevant closure with your domain class.
+To add an event simply register the relevant method with your domain class.
 
 {warning}
 Do not attempt to flush the session within an event (such as with obj.save(flush:true)). Since events are fired during flushing this will cause a StackOverflowError.

--- a/src/es/guide/GORM/advancedGORMFeatures/eventsAutoTimestamping.gdoc
+++ b/src/es/guide/GORM/advancedGORMFeatures/eventsAutoTimestamping.gdoc
@@ -9,7 +9,7 @@ GORM supports the registration of events as methods that get fired when certain 
 * @afterDelete@ - Executed after an object has been deleted
 * @onLoad@ - Executed when an object is loaded from the database
 
-To add an event simply register the relevant closure with your domain class.
+To add an event simply register the relevant method with your domain class.
 
 {warning}
 Do not attempt to flush the session within an event (such as with obj.save(flush:true)). Since events are fired during flushing this will cause a StackOverflowError.

--- a/src/fr/guide/GORM/advancedGORMFeatures/eventsAutoTimestamping.gdoc
+++ b/src/fr/guide/GORM/advancedGORMFeatures/eventsAutoTimestamping.gdoc
@@ -9,7 +9,7 @@ GORM supports the registration of events as methods that get fired when certain 
 * @afterDelete@ - Executed after an object has been deleted
 * @onLoad@ - Executed when an object is loaded from the database
 
-To add an event simply register the relevant closure with your domain class.
+To add an event simply register the relevant method with your domain class.
 
 {warning}
 Do not attempt to flush the session within an event (such as with obj.save(flush:true)). Since events are fired during flushing this will cause a StackOverflowError.

--- a/src/pt_PT/guide/GORM/advancedGORMFeatures/eventsAutoTimestamping.gdoc
+++ b/src/pt_PT/guide/GORM/advancedGORMFeatures/eventsAutoTimestamping.gdoc
@@ -9,7 +9,7 @@ GORM supports the registration of events as methods that get fired when certain 
 * @afterDelete@ - Executed after an object has been deleted
 * @onLoad@ - Executed when an object is loaded from the database
 
-To add an event simply register the relevant closure with your domain class.
+To add an event simply register the relevant method with your domain class.
 
 {warning}
 Do not attempt to flush the session within an event (such as with obj.save(flush:true)). Since events are fired during flushing this will cause a StackOverflowError.

--- a/src/th/guide/GORM/advancedGORMFeatures/eventsAutoTimestamping.gdoc
+++ b/src/th/guide/GORM/advancedGORMFeatures/eventsAutoTimestamping.gdoc
@@ -9,7 +9,7 @@ GORM supports the registration of events as methods that get fired when certain 
 * @afterDelete@ - Executed after an object has been deleted
 * @onLoad@ - Executed when an object is loaded from the database
 
-To add an event simply register the relevant closure with your domain class.
+To add an event simply register the relevant method with your domain class.
 
 {warning}
 Do not attempt to flush the session within an event (such as with obj.save(flush:true)). Since events are fired during flushing this will cause a StackOverflowError.

--- a/src/zh_CN/guide/GORM/advancedGORMFeatures/eventsAutoTimestamping.gdoc
+++ b/src/zh_CN/guide/GORM/advancedGORMFeatures/eventsAutoTimestamping.gdoc
@@ -9,7 +9,7 @@ GORM supports the registration of events as methods that get fired when certain 
 * @afterDelete@ - Executed after an object has been deleted
 * @onLoad@ - Executed when an object is loaded from the database
 
-To add an event simply register the relevant closure with your domain class.
+To add an event simply register the relevant method with your domain class.
 
 {warning}
 Do not attempt to flush the session within an event (such as with obj.save(flush:true)). Since events are fired during flushing this will cause a StackOverflowError.

--- a/src/zh_TW/guide/GORM/advancedGORMFeatures/eventsAutoTimestamping.gdoc
+++ b/src/zh_TW/guide/GORM/advancedGORMFeatures/eventsAutoTimestamping.gdoc
@@ -9,7 +9,7 @@ GORM supports the registration of events as methods that get fired when certain 
 * @afterDelete@ - Executed after an object has been deleted
 * @onLoad@ - Executed when an object is loaded from the database
 
-To add an event simply register the relevant closure with your domain class.
+To add an event simply register the relevant method with your domain class.
 
 {warning}
 Do not attempt to flush the session within an event (such as with obj.save(flush:true)). Since events are fired during flushing this will cause a StackOverflowError.


### PR DESCRIPTION
Now, all sample code are written as 'method'.
