### PR TITLE
Added `inRange` and `Rlike` to GORM finders documentation

### DIFF
--- a/src/en/guide/GORM/querying/finders.gdoc
+++ b/src/en/guide/GORM/querying/finders.gdoc
@@ -58,6 +58,8 @@ The possible comparators include:
 * @Like@ - Equivalent to a SQL like expression
 * @Ilike@ - Similar to a @Like@, except case insensitive
 * @NotEqual@ - Negates equality
+* @InRange@ - Between the @from@ and @to@ values of a Groovy Range
+* @Rlike@ - Performs a Regexp LIKE in MySQL or Oracle otherwise falls back to @Like@
 * @Between@ - Between two values (requires two arguments)
 * @IsNotNull@ - Not a null value (doesn't take an argument)
 * @IsNull@ - Is a null value (doesn't take an argument)


### PR DESCRIPTION
The InRange and Rlike finders do not seem to be currently in the documentation.

I guess this needs to pass into the other i18n docs as well?
