### PR TITLE
Correcting folder/group name for springloaded jar

### DIFF
--- a/src/en/guide/contributing/build.gdoc
+++ b/src/en/guide/contributing/build.gdoc
@@ -58,7 +58,7 @@ Before importing projects to STS do the following action:
 * Edit grails-scripts/.classpath and remove the line "<classpathentry kind="src" path="../scripts"/>".
 
 Use "Import->General->Existing Projects into Workspace" to import all projects to STS. There will be a few build errors. To fix them do the following:
-* Add the springloaded-core JAR file in $GRAILS_HOME/lib/com.springsource.springloaded/springloaded-core/jars to grails-core's classpath.
+* Add the springloaded-core JAR file in $GRAILS_HOME/lib/org.springsource.springloaded/springloaded-core/jars to grails-core's classpath.
 * Remove "src/test/groovy" from grails-plugin-testing's source path GRECLIPSE-1067
 * Add the jsp-api JAR file in $GRAILS_HOME/lib/javax.servlet.jsp/jsp-api/jars to the classpath of grails-web
 * Fix the source path of grails-scripts. Add linked source folder linking to "../scripts". If you get build errors in grails-scripts, do "../gradlew cleanEclipse eclipse" in that directory and edit the .classpath file again (remove the line "<classpathentry kind="src" path="../scripts"/>"). Remove possible empty "scripts" directory under grails-scripts if you are not able to add the linked folder.


### PR DESCRIPTION
Correcting folder/group name for springloaded jar com.springsource -> org.springsource
