### PR TITLE
fix unintended strikethrough in commandLine forkedMode documentation

### DIFF
--- a/src/en/guide/commandLine/forkedMode.gdoc
+++ b/src/en/guide/commandLine/forkedMode.gdoc
@@ -64,7 +64,7 @@ $ grails> restart-daemon
 {code}
  
 
-h4. Debugging and Forked Execution (--debug vs --debug-fork)
+h4. Debugging and Forked Execution (\--debug vs \--debug-fork)
 
 An important consideration when using forked execution is that the @debug@ argument will allow a remote debugger to be attached to the build JVM but not the JVM that your application is running in. To debug your application you should use the @debug-fork@ argument:
 


### PR DESCRIPTION
In the section heading for "Debugging and Forked Execution (--debug vs --debug-fork)",
the double-hyphens before the --debug and --debug-fork were not being rendered correctly,
and debug was being rendered as a strikethrough.  This change appears to result in the
intended rendering.
