### PR TITLE
Don't us appears next to included spock by default

### DIFF
--- a/src/en/guide/upgradingFromPreviousVersionsOfGrails.gdoc
+++ b/src/en/guide/upgradingFromPreviousVersionsOfGrails.gdoc
@@ -7,7 +7,7 @@ A number of changes need to considered when upgrading your application from Grai
 * Grails core dependencies rearranged
 * Tomcat and Hibernate plugins independently versioned now (breaking!)
 * Scaffolding is now a separate plugin
-* Spock included by default - don't us
+* Spock included by default
 * Dependency injection does not work in integration tests by default 
 * Forked execution for tests
 * Reloading in @run-app@ won't work by default on upgraded apps


### PR DESCRIPTION
Removed the "don't us" at the end of this line

Spock included by default - don't us
