### PR TITLE
Quick fix for test names

### DIFF
--- a/src/en/ref/Command Line/create-integration-test.gdoc
+++ b/src/en/ref/Command Line/create-integration-test.gdoc
@@ -18,7 +18,7 @@ Creates an integration test for the given base name. The argument is optional, b
 
 An integration test differs from a unit test in that the Grails environment is loaded for each test execution. Refer to the section on [Unit Testing|guide:testing] of the user guide for information on unit vs. integration testing.
 
-The name of the test can include a Java package, such as @org.bookstore@ in the final example above, but if one is not provided a default is used. So the second example will create the file @test/integration/<appname>/BookTests.groovy@ whereas the last one will create @test/integration/org/bookstore/BookTests.groovy@ directory. Note that the first letter of the test name is always upper-cased when determining the class name.
+The name of the test can include a Java package, such as @org.bookstore@ in the final example above, but if one is not provided a default is used. So the second example will create the file @test/integration/<appname>/BookSpec.groovy@ whereas the last one will create @test/integration/org/bookstore/BookSpec.groovy@ directory. Note that the first letter of the test name is always upper-cased when determining the class name.
 
 If you want the command to default to a different package for tests, provide a value for @grails.project.groupId@ in the [runtime configuration|guide:config].
 

--- a/src/en/ref/Command Line/create-unit-test.gdoc
+++ b/src/en/ref/Command Line/create-unit-test.gdoc
@@ -20,7 +20,7 @@ A unit test differs from an integration test in that the Grails environment is n
 
 Refer to the section on [Unit Testing|guide:testing] of the user guide for information on unit vs. integration testing.
 
-The name of the test can include a Java package, such as @org.bookstore@ in the final example above, but if one is not provided a default is used. So the second example will create the file @test/integration/<appname>/BookTests.groovy@ whereas the last one will create @test/integration/org/bookstore/BookTests.groovy@ directory. Note that the first letter of the test name is always upper-cased when determining the class name.
+The name of the test can include a Java package, such as @org.bookstore@ in the final example above, but if one is not provided a default is used. So the second example will create the file @test/integration/<appname>/BookSpec.groovy@ whereas the last one will create @test/integration/org/bookstore/BookSpec.groovy@ directory. Note that the first letter of the test name is always upper-cased when determining the class name.
 
 If you want the command to default to a different package for tests, provide a value for @grails.project.groupId@ in the [runtime configuration|guide:config].
 


### PR DESCRIPTION
Replaced the JUnit convention names to Spock. 
