### PR TITLE
custom link should be created with createLink instead of link

### DIFF
--- a/src/en/guide/webServices/REST/hypermedia/hal.gdoc
+++ b/src/en/guide/webServices/REST/hypermedia/hal.gdoc
@@ -278,7 +278,7 @@ However you can customize link rendering using the @link@ method that is added t
 
 {code}
 def show(Book book) {
-    book.link rel:'publisher', href: g.link(resource:"publisher", params:[bookId: book.id])
+    book.link rel:'publisher', href: g.createLink(absolute: true, resource:"publisher", params:[bookId: book.id])
     respond book
 }
 {code}


### PR DESCRIPTION
In the "Customizing Link Rendering" section of "HAL Support", the example code doesn't produce the resulting output shown below.