### PR TITLE
g:link tag documentaiton Adding Example for resource and description arg

### DIFF
--- a/src/en/ref/Tags/link.gdoc
+++ b/src/en/ref/Tags/link.gdoc
@@ -47,6 +47,20 @@ Example usages for above controller:
 <g:link controller="book" base="http://admin.mygreatsite.com">Book Home</g:link>
 {code}
 
+Example Usage for a Resftul Resource:
+
+{code:java}
+static mappings = {
+    "/books"(resources: 'book')
+}
+{code}
+
+{code:xml}
+<g:link resource="book">Book Home</g:link>
+<g:link resource="book" id="${book.id}">Book Show</g:link>
+<g:link resource="book" action="create">New Book</g:link>
+{code}
+
 Example as a method call in GSP only:
 
 {code:java}
@@ -65,6 +79,7 @@ Attributes
 
 * @action@ (optional) - the name of the action to use in the link; if not specified the default action will be linked
 * @controller@ (optional) - the name of the controller to use in the link; if not specified the current controller will be linked
+* @resource@ (optional)   - the name of the resource url mapping to use in the link; if not specified controller should be used
 * @namespace@ (optional) - the namespace of the controller to use in the link
 * @plugin@ (optional) - the name of the plugin which provides the controller
 * @elementId@ (optional) - this value will be used to populate the @id@ attribute of the generated href


### PR DESCRIPTION
The G:link tag has a resource="" argument for creating RESTFul links but it is undocumented.
