### PR TITLE
Updated the Simpson example to use 'ref'

### DIFF
--- a/src/en/guide/spring/theBeanBuilderDSLExplained.gdoc
+++ b/src/en/guide/spring/theBeanBuilderDSLExplained.gdoc
@@ -135,7 +135,7 @@ bb.beans {
             age = 45
             props = [overweight: true, height: "1.8m"]
         }
-        children = [bart, lisa]
+        children = [ref('bart'), ref('lisa')]
     }
 
     bart(Person) {
@@ -166,7 +166,7 @@ bb.beans {
             age = 45
             props = [overweight: true, height: "1.8m"]
         }
-        children = [bart, lisa]
+        children = [ref('bart'), ref('lisa')]
     }
 }
 {code}


### PR DESCRIPTION
In the current documentation, the bean definition surrounding the Simpson's characters doesn't run successfully. This is because bart and lisa are defined after marge, yet are referenced without 'ref'.

A quick scan didn't reveal any other violations of this rule, other than this example. An alternative solution would be to move lisa and bart above the marge bean definition.
