### PR TITLE
First cut of asset-pipeline doc update

### DIFF
--- a/src/en/guide/theWebLayer/gsp/resources.gdoc
+++ b/src/en/guide/theWebLayer/gsp/resources.gdoc
@@ -1,26 +1,18 @@
-{note}
-TBD... This section of material will be updated to cover the asset-pipeline plugin before Grails 2.4 is released.
-{note}
+Grails 2.0 integrates with the [Asset Pipeline plugin|http://grails.org/plugin/asset-pipeline] to provide sophisticated static asset management. This plugin is installed by default in new Grails applications.
 
-Grails 2.0 integrates with the [Resources plugin|http://grails.org/plugin/resources] to provide sophisticated static resource management. This plugin is installed by default in new Grails applications.
-
-The basic way to include a link to a static resource in your application is to use the [resource|tags] tag. This simple approach creates a URI pointing to the file.
+The basic way to include a link to a static asset in your application is to use the [resource|tags] tag. This simple approach creates a URI pointing to the file.
 
 However modern applications with dependencies on multiple JavaScript and CSS libraries and frameworks (as well as dependencies on multiple Grails plugins) require something more powerful.
 
-The issues that the Resources framework tackles are:
+The issues that the Asset-Pipeline plugin tackles are:
 
+* Reduced Dependence - The plugin has compression, minification, and cache-digests built in.
+* Easy Debugging - Makes for easy debugging by keeping files seperate in development mode.
+* Asset Bundling using require [directives|http://bertramdev.github.io/asset-pipeline/guide/usage.html#directives].
 * Web application performance tuning is difficult
-* Correct ordering of resources, and deferred inclusion of JavaScript
-* Resources that depend on others that must be loaded first
-* The need for a standard way to expose static resources in plugins and applications
-* The need for an extensible processing chain to optimize resources
-* Preventing multiple inclusion of the same resource
+* The need for a standard way to expose static assets in plugins and applications
+* The need for extinsible processing to make languages like LESS or Coffee first class citizens.
 
-The plugin achieves this by introducing new artefacts and processing the resources using the server's local file system.
+The asset-pipeline allows you to define your javascript or css requirements right at the top of the file and they get compiled on War creation.
 
-It adds artefacts for declaring resources, for declaring "mappers" that can process resources, and a servlet filter to serve processed resources.
-
-What you get is an incredibly advanced resource system that enables you to easily create highly optimized web applications that run the same in development and in production.
-
-The Resources plugin documentation provides a more detailed overview of the [concepts|http://grails-plugins.github.com/grails-resources/] which will be beneficial when reading the following guide.
+Take a look at the [documentation|http://bertramdev.github.io/asset-pipeline] for the asset-pipeline to get started.


### PR DESCRIPTION
This is a first cut of updating the documentation for the use of the asset-pipeline plugin.
