### PR TITLE
fix to promise list documentation

### DIFF
--- a/src/en/guide/async/promises.gdoc
+++ b/src/en/guide/async/promises.gdoc
@@ -85,7 +85,7 @@ The easiest way to create a promise list or map is via the @tasks@ method of the
 {code}
 import static grails.async.Promises.*
 
-def promiseList = tasks { 2 * 2 }, { 4 * 4}, { 8 * 8 }
+def promiseList = tasks([{ 2 * 2 }, { 4 * 4}, { 8 * 8 }])
 
 assert [4,16,64] == promiseList.get()
 {code}


### PR DESCRIPTION
The example given for promise lists does not work (error: "expecting an identifier, found '{'"). My edit works, but I'm not sure if it's the grooviest way to express it.
