### PR TITLE
Tell users to use the latest verison of ehcache

### DIFF
--- a/src/en/guide/upgradingFromPreviousVersionsOfGrails.gdoc
+++ b/src/en/guide/upgradingFromPreviousVersionsOfGrails.gdoc
@@ -43,7 +43,7 @@ h4. Dependency Metadata Changes
 In addition, the POM and dependency metadata for Grails 2.3 has been re-arranged and cleaned up so that only direct dependencies are specified for an application and all other dependencies are inherited transitvely. This has implications to the upgrade since, for example, Ehcache is now a transitive dependency of the Hibernate plugin, whilst before it was a direct dependency. If get a compilation error related to Ehcache, it is most likely that you don't have the Hibernate plugin installed and need to directly declare the Ehcache dependency:
 
 {code}
-compile "net.sf.ehcache:ehcache-core:2.4.6"
+compile "net.sf.ehcache:ehcache:2.8.1"
 {code}
 
 In addition, excludes may no longer work and may need adjusting when upgrading due to how the metadata has changed. Run the [dependency-report|commandLine] to see the new dependency metadata and make adjustments accordingly.


### PR DESCRIPTION
The documentation refers to ehcache 2.4.6, which is very much out of date. Refer to the latest version (which as of right now is 2.8.1) instead.