### PR TITLE
GRAILS-11309 hasErrors documentation: it.defaultMessage is probably not the best example

### DIFF
--- a/src/en/ref/Tags/hasErrors.gdoc
+++ b/src/en/ref/Tags/hasErrors.gdoc
@@ -10,7 +10,7 @@ Checks whether there are any errors for any bean throughout the request scope:
 
 {code:xml}
 <g:hasErrors>
-    <g:eachError><p>${it.defaultMessage}</p></g:eachError>
+    <g:eachError><p><g:message error="${it}"/></p></g:eachError>
 </g:hasErrors>
 {code}
 
@@ -18,7 +18,7 @@ Checks whether there are any errors for the specified bean
 
 {code:xml}
 <g:hasErrors bean="${book}">
-    <g:eachError><p>${it.defaultMessage}</p></g:eachError>
+    <g:eachError><p><g:message error="${it}"/></p></g:eachError>
 </g:hasErrors>
 {code}
 


### PR DESCRIPTION
http://grails.org/doc/latest/ref/Tags/hasErrors.html

using it.defaultMessage with a custom validator produces a message like:

Property [{0}] of class [{1}] with value [{2}] does not pass custom validation

Seems like a better example would use g:message which actually resolves the code:

```
<g:message error="${it}"/>
```
