### PR TITLE
Fixed typo in 'More Advanced Subqueries in GORM' section

### DIFF
--- a/src/en/guide/introduction/whatsNew24.gdoc
+++ b/src/en/guide/introduction/whatsNew24.gdoc
@@ -107,7 +107,7 @@ See the [static compilation and type checking|guide:staticTypeCheckingAndCompila
 
 h4. More Advanced Subqueries in GORM
 
-The support for subqueries has been extended. You can no use @in@ with nested subqueries:
+The support for subqueries has been extended. You can now use @in@ with nested subqueries:
 
 {code}
 def results = Person.where {


### PR DESCRIPTION
Correction of minor typo in the documentation for 'Whats new in 2.4'
