### PR TITLE
Document the new Servlet API requirements in Grails 2.4

### DIFF
--- a/src/en/guide/gettingStarted/supportedJavaEEContainers.gdoc
+++ b/src/en/guide/gettingStarted/supportedJavaEEContainers.gdoc
@@ -24,4 +24,8 @@ Grails runs on any container that supports Servlet 2.5 and above and is known to
 It's required to set "-Xverify:none" in "Application servers > server > Process Definition > Java Virtual Machine > Generic JVM arguments" for older versions of WebSphere. This is no longer needed for WebSphere version 8 or newer.
 {note}
 
+{note}
+Grails 2.4 and later require Servlet 3.0 and above.
+{note}
+
 Some containers have bugs however, which in most cases can be worked around. A [list of known deployment issues|http://grails.org/Deployment] can be found on the Grails wiki.

--- a/src/en/guide/introduction/whatsNew24.gdoc
+++ b/src/en/guide/introduction/whatsNew24.gdoc
@@ -12,6 +12,10 @@ h4. Hibernate 4.3
 
 Grails 2.4 now uses Hibernate 4.3.5 by default (Hibernate 3 is still available as an optional install).
 
+h4. Servlet API 3.0 minimum
+
+Grails 2.4 requires container compatible with Servlet 3.0 and above.
+
 h4. Standalone GORM and GSP
 
 GORM and GSP can now be used outside of Grails. See the following guides / examples for more information:


### PR DESCRIPTION
As @graemerocher mentioned in [GRAILS-11450](https://jira.grails.org/browse/GRAILS-11450) Grails 2.4 requires Servlet API 3.0 and above.
I didn't see this anywhere in the docs, so I added this.
