### PR TITLE
Remove Servlet API 3.0 dependency references.

### DIFF
--- a/src/en/guide/gettingStarted/supportedJavaEEContainers.gdoc
+++ b/src/en/guide/gettingStarted/supportedJavaEEContainers.gdoc
@@ -24,8 +24,4 @@ Grails runs on any container that supports Servlet 2.5 and above and is known to
 It's required to set "-Xverify:none" in "Application servers > server > Process Definition > Java Virtual Machine > Generic JVM arguments" for older versions of WebSphere. This is no longer needed for WebSphere version 8 or newer.
 {note}
 
-{note}
-Grails 2.4 and later require Servlet 3.0 and above.
-{note}
-
 Some containers have bugs however, which in most cases can be worked around. A [list of known deployment issues|http://grails.org/Deployment] can be found on the Grails wiki.

--- a/src/en/guide/introduction/whatsNew24.gdoc
+++ b/src/en/guide/introduction/whatsNew24.gdoc
@@ -12,10 +12,6 @@ h4. Hibernate 4.3
 
 Grails 2.4 now uses Hibernate 4.3.5 by default (Hibernate 3 is still available as an optional install).
 
-h4. Servlet API 3.0 minimum
-
-Grails 2.4 requires container compatible with Servlet 3.0 and above.
-
 h4. Standalone GORM and GSP
 
 GORM and GSP can now be used outside of Grails. See the following guides / examples for more information:


### PR DESCRIPTION
As detailed in the comments to [GRAILS-11466](https://jira.grails.org/browse/GRAILS-11466) and [GRAILS-11450](https://jira.grails.org/browse/GRAILS-11450) the Servlet API 3.0 dependency no longer exists - but it's in the 2.4.1 docs now.

It would be great if the docs could be updated between grails-core releases, too.
