### PR TITLE
fix docs that incorrectly specify string instead of list, add real example

### DIFF
--- a/src/en/guide/commandLine/forkedMode.gdoc
+++ b/src/en/guide/commandLine/forkedMode.gdoc
@@ -99,10 +99,10 @@ Then just us the regular @run-app@ command as per normal. Note that in forked mo
 grails stop-app
 {code}
 
-To customize the JVM arguments passed to the forked JVM you can specify a map instead:
+To customize the JVM arguments passed to the forked JVM you can specify a list instead:
 
 {code}
-grails.project.fork.run= [maxMemory:1024, minMemory:64, debug:false, maxPerm:256, jvmArgs: '..arbitrary JVM arguments..']
+grails.project.fork.run= [maxMemory:1024, minMemory:64, debug:false, maxPerm:256, jvmArgs: ['-Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005']]
 {code}
 
 h4. Auto-deploying additional WAR files in Forked Mode


### PR DESCRIPTION
Docs incorrectly specify that the `jvmArgs` map value should be a `String` when it actually wants a `List<String>`.

Also added a real-world example showing how to set jvm flags so that the debugger won't suspend rather than the less real value of `'..arbitrary JVM arguments..'`.