### PR TITLE
Update logging.gdoc

### DIFF
--- a/src/en/guide/conf/config/logging.gdoc
+++ b/src/en/guide/conf/config/logging.gdoc
@@ -413,7 +413,7 @@ log4j = {
         ...
     }
 
-    info additivity: false
+    info additivity: false,
          stdout: \["grails.app.controllers.BookController",
                   "grails.app.services.BookService"\]
 }


### PR DESCRIPTION
Added missing comma in example of using 'additivity' for a logger
