### PR TITLE
fix spring links with trailing period

### DIFF
--- a/src/en/guide/spring.gdoc
+++ b/src/en/guide/spring.gdoc
@@ -1,1 +1,1 @@
-This section is for advanced users and those who are interested in how Grails integrates with and builds on the "Spring Framework":http://www.springframework.org/. It is also useful for [plugin developers|guide:plugins] considering doing runtime configuration Grails.
+This section is for advanced users and those who are interested in how Grails integrates with and builds on the [Spring Framework|http://www.springframework.org/]. It is also useful for [plugin developers|guide:plugins] considering doing runtime configuration Grails.

--- a/src/es/guide/spring.gdoc
+++ b/src/es/guide/spring.gdoc
@@ -1,1 +1,1 @@
-This section is for advanced users and those who are interested in how Grails integrates with and builds on the "Spring Framework":http://www.springframework.org/. It is also useful for [plugin developers|guide:plugins] considering doing runtime configuration Grails.
+This section is for advanced users and those who are interested in how Grails integrates with and builds on the [Spring Framework|http://www.springframework.org/]. It is also useful for [plugin developers|guide:plugins] considering doing runtime configuration Grails.

--- a/src/fr/guide/spring.gdoc
+++ b/src/fr/guide/spring.gdoc
@@ -1,1 +1,1 @@
-This section is for advanced users and those who are interested in how Grails integrates with and builds on the "Spring Framework":http://www.springframework.org/. It is also useful for [plugin developers|guide:plugins] considering doing runtime configuration Grails.
+This section is for advanced users and those who are interested in how Grails integrates with and builds on the [Spring Framework|http://www.springframework.org/]. It is also useful for [plugin developers|guide:plugins] considering doing runtime configuration Grails.

--- a/src/pt_PT/guide/spring.gdoc
+++ b/src/pt_PT/guide/spring.gdoc
@@ -1,1 +1,1 @@
-This section is for advanced users and those who are interested in how Grails integrates with and builds on the "Spring Framework":http://www.springframework.org/. It is also useful for [plugin developers|guide:plugins] considering doing runtime configuration Grails.
+This section is for advanced users and those who are interested in how Grails integrates with and builds on the [Spring Framework|http://www.springframework.org/]. It is also useful for [plugin developers|guide:plugins] considering doing runtime configuration Grails.

--- a/src/th/guide/spring.gdoc
+++ b/src/th/guide/spring.gdoc
@@ -1,1 +1,1 @@
-This section is for advanced users and those who are interested in how Grails integrates with and builds on the "Spring Framework":http://www.springframework.org/. It is also useful for [plugin developers|guide:plugins] considering doing runtime configuration Grails.
+This section is for advanced users and those who are interested in how Grails integrates with and builds on the [Spring Framework|http://www.springframework.org/]. It is also useful for [plugin developers|guide:plugins] considering doing runtime configuration Grails.

--- a/src/zh_CN/guide/spring.gdoc
+++ b/src/zh_CN/guide/spring.gdoc
@@ -1,1 +1,1 @@
-This section is for advanced users and those who are interested in how Grails integrates with and builds on the "Spring Framework":http://www.springframework.org/. It is also useful for [plugin developers|guide:plugins] considering doing runtime configuration Grails.
+This section is for advanced users and those who are interested in how Grails integrates with and builds on the [Spring Framework|http://www.springframework.org/]. It is also useful for [plugin developers|guide:plugins] considering doing runtime configuration Grails.

--- a/src/zh_TW/guide/spring.gdoc
+++ b/src/zh_TW/guide/spring.gdoc
@@ -1,1 +1,1 @@
-This section is for advanced users and those who are interested in how Grails integrates with and builds on the "Spring Framework":http://www.springframework.org/. It is also useful for [plugin developers|guide:plugins] considering doing runtime configuration Grails.
+This section is for advanced users and those who are interested in how Grails integrates with and builds on the [Spring Framework|http://www.springframework.org/]. It is also useful for [plugin developers|guide:plugins] considering doing runtime configuration Grails.


### PR DESCRIPTION
Some links to Spring Framework were including the trailing period for the sentence. Changing the link syntax should fix the issue.
