### PR TITLE
Fix incorrect doc on `UrlConstraint` using `commons-validator`.

### DIFF
--- a/src/en/ref/Constraints/url.gdoc
+++ b/src/en/ref/Constraints/url.gdoc
@@ -12,6 +12,6 @@ homePage url: true
 
 h2. Description
 
-Set to @true@ if a string value must be a URL. Internally uses the @org.apache.commons.validator.UrlValidator@ class.
+Set to @true@ if a string value must be a URL.
 
 Error Code: @className.propertyName.url.invalid@

--- a/src/es/ref/Constraints/url.gdoc
+++ b/src/es/ref/Constraints/url.gdoc
@@ -12,6 +12,6 @@ homePage url: true
 
 h2. Description
 
-Set to @true@ if a string value must be a URL. Internally uses the @org.apache.commons.validator.UrlValidator@ class.
+Set to @true@ if a string value must be a URL.
 
 Error Code: @className.propertyName.url.invalid@

--- a/src/fr/ref/Constraints/url.gdoc
+++ b/src/fr/ref/Constraints/url.gdoc
@@ -12,6 +12,6 @@ homePage url: true
 
 h2. Description
 
-Set to @true@ if a string value must be a URL. Internally uses the @org.apache.commons.validator.UrlValidator@ class.
+Set to @true@ if a string value must be a URL.
 
 Error Code: @className.propertyName.url.invalid@

--- a/src/th/ref/Constraints/url.gdoc
+++ b/src/th/ref/Constraints/url.gdoc
@@ -12,6 +12,6 @@ homePage url: true
 
 h2. Description
 
-Set to @true@ if a string value must be a URL. Internally uses the @org.apache.commons.validator.UrlValidator@ class.
+Set to @true@ if a string value must be a URL.
 
 Error Code: @className.propertyName.url.invalid@

--- a/src/zh_CN/ref/Constraints/url.gdoc
+++ b/src/zh_CN/ref/Constraints/url.gdoc
@@ -12,6 +12,6 @@ homePage url: true
 
 h2. Description
 
-Set to @true@ if a string value must be a URL. Internally uses the @org.apache.commons.validator.UrlValidator@ class.
+Set to @true@ if a string value must be a URL.
 
 Error Code: @className.propertyName.url.invalid@

--- a/src/zh_TW/ref/Constraints/url.gdoc
+++ b/src/zh_TW/ref/Constraints/url.gdoc
@@ -12,6 +12,6 @@ homePage url: true
 
 h2. Description
 
-Set to @true@ if a string value must be a URL. Internally uses the @org.apache.commons.validator.UrlValidator@ class.
+Set to @true@ if a string value must be a URL.
 
 Error Code: @className.propertyName.url.invalid@


### PR DESCRIPTION
`UrlConstraint` uses its own `UrlValidator` and `DomainValidator`, and does *not* use `commons-validator`.  This matters when trying to get Grails to accept new TLDs, such as `.pizza` or `.wtf`: upgrading `commons-validator` to the latest version won't help, no matter how hard you try, since it is not used to validate URLs, and the Grails `DomainValidator` class maintains its own TLD list.

OTOH, `EmailConstraint` and `CreditCardConstraint` *do* use the corresponding `commons-validator` classes.