### PR TITLE
fix docs for hibernate second-level cache

### DIFF
--- a/src/en/guide/GORM/advancedGORMFeatures/ormdsl/caching.gdoc
+++ b/src/en/guide/GORM/advancedGORMFeatures/ormdsl/caching.gdoc
@@ -1,13 +1,14 @@
 h4. Setting up caching
 
-"Hibernate":http://www.hibernate.org/ features a second-level cache with a customizable cache provider. This needs to be configured in the @grails-app/conf/DataSource.groovy@ file as follows:
+"Hibernate":http://www.hibernate.org/ features a second-level cache with a customizable cache provider. This needs to be configured in the @grails-app/conf/application.yml@ file as follows:
 
-{code:java}
-hibernate {
-    cache.use_second_level_cache=true
-    cache.use_query_cache=true
-    cache.provider_class='org.hibernate.cache.EhCacheProvider'
-}
+{code}
+hibernate:
+  cache:
+    use_second_level_cache: true
+    provider_class: net.sf.ehcache.hibernate.EhCacheProvider
+    region:
+       factory_class: org.hibernate.cache.ehcache.EhCacheRegionFactory
 {code}
 
 You can customize any of these settings, for example to use a distributed caching mechanism.


### PR DESCRIPTION
Docs still refer to `DataSource.groovy`