### PR TITLE
Fixing problem with TimeZone link in formatDate tag

### DIFF
--- a/src/en/ref/Tags/formatDate.gdoc
+++ b/src/en/ref/Tags/formatDate.gdoc
@@ -30,7 +30,7 @@ Attributes
 * @format@ (optional) - The formatting pattern to use for the date, see [SimpleDateFormat|api:java.text.SimpleDateFormat]
 * @formatName@ (optional) - Look up @format@ from the default MessageSource / ResourceBundle (i18n/*.properties file) with this key. If @format@ and @formatName@ are empty, @format@ is looked up with '@default.date.format@' key. Defaults to 'yyyy-MM-dd HH:mm:ss z' if the key not specified
 * @type@ (optional) - The type of format to use for the date / time. @format@ or @formatName@ aren't used when @type@ is specified. Possible values: 'date' - shows only date part, 'time' - shows only time part, 'both'/'datetime' - shows date and time
-* @timeZone@ (optional) - Sets the time zone for formatting. See [TimeZone|api:java.util.SimpleDateFormat] class.
+* @timeZone@ (optional) - Sets the time zone for formatting. See [TimeZone|api:java.util.TimeZone] class.
 * @locale@ (optional) - Force the locale for formatting.
 * @style@ (optional) - Use default date/time formatting of the country specified by the locale. Possible values: SHORT (default), MEDIUM, LONG, FULL . See [DateFormat|api:java.text.DateFormat] for explanation.
 * @dateStyle@ (optional) - Set separate @style@ for the date part.


### PR DESCRIPTION
formatDate tag has a wrong link to TimeZone class api doc.