### PR TITLE
Changed new path for Java files to src/main/java

### DIFF
--- a/src/en/guide/upgrading.gdoc
+++ b/src/en/guide/upgrading.gdoc
@@ -27,7 +27,7 @@ The location of certain files have changed or been replaced with other files in 
 @grails-app/conf/BootStrap.groovy@ | @grails-app/init/BootStrap.groovy@ | Moved since grails-app/conf is not a source directory anymore
 @scripts@ | @src/main/scripts@ | Moved for consistency with Gradle
 @src/groovy@ | @src/main/groovy@ | Moved for consistency with Gradle
-@src/java@ | @src/main/groovy@ | Moved for consistency with Gradle
+@src/java@ | @src/main/java@ | Moved for consistency with Gradle
 @test/unit@ | @src/test/groovy@ | Moved for consistency with Gradle
 @test/integration@ | @src/integration-test/groovy@ | Moved for consistency with Gradle
 @web-app@ | @src/main/webapp@ | Moved for consistency with Gradle


### PR DESCRIPTION
If this isn't a typo, then why is there no longer a java directory?