### PR TITLE
Fix missing with in Datasource documentation

### DIFF
--- a/src/en/guide/conf/dataSource.gdoc
+++ b/src/en/guide/conf/dataSource.gdoc
@@ -12,7 +12,7 @@ Drivers typically come in the form of a JAR archive. It's best to use the depend
 
 If you can't use dependency resolution then just put the JAR in your project's @lib@ directory.
 
-Once you have the JAR resolved you need to get familiar Grails' DataSource descriptor file located at @grails-app/conf/DataSource.groovy@. This file contains the dataSource definition which includes the following settings:
+Once you have the JAR resolved you need to get familiar with Grails' DataSource descriptor file located at @grails-app/conf/DataSource.groovy@. This file contains the dataSource definition which includes the following settings:
 
 * @driverClassName@ - The class name of the JDBC driver
 * @username@ - The username used to establish a JDBC connection


### PR DESCRIPTION
A minor mistake in sentence in Datasource documentation.