### PR TITLE
Matching Requests with Inteceptors - Made uri details more precise

### DIFF
--- a/src/en/guide/theWebLayer/interceptors/interceptorMatching.gdoc
+++ b/src/en/guide/theWebLayer/interceptors/interceptorMatching.gdoc
@@ -39,4 +39,4 @@ All named arguments accept either a String or a Regex expression. The possible n
 * @controller@ - The name of the controller
 * @action@ - The name of the action
 * @method@ - The HTTP method
-* @uri@ - The URI of the request (cannot be used in combination with other arguments)
+* @uri@ - The URI of the request. If this argument is used then all other arguments will be ignored and only this will be used.


### PR DESCRIPTION
"cannot be used in combination with other arguments" was not clear about what would happen in case it is used together. Added the details for that.