### PR TITLE
Interceptor - Added details for multiple matchers

### DIFF
--- a/src/en/guide/theWebLayer/interceptors/interceptorMatching.gdoc
+++ b/src/en/guide/theWebLayer/interceptors/interceptorMatching.gdoc
@@ -32,7 +32,7 @@ class LoggingInterceptor {
 }
 {code}
 
-You can any number of matchers defined in your interceptor. They will be executed in the order in which they have been defined. For example the above interceptor will match for all of the following:
+You can use any number of matchers defined in your interceptor. They will be executed in the order in which they have been defined. For example the above interceptor will match for all of the following:
 
 * when the @show@ action of @BookController@ is called 
 * when @AuthorController@ or @PublisherController@ is called

--- a/src/en/guide/theWebLayer/interceptors/interceptorMatching.gdoc
+++ b/src/en/guide/theWebLayer/interceptors/interceptorMatching.gdoc
@@ -19,7 +19,6 @@ class AuthInterceptor {
 
 You can also perform matching using named argument:
 
-
 {code}
 class LoggingInterceptor {
   LoggingInterceptor() {
@@ -32,6 +31,11 @@ class LoggingInterceptor {
   }
 }
 {code}
+
+You can any number of matchers defined in your interceptor. They will be executed in the order in which they have been defined. For example the above interceptor will match for all of the following:
+
+* when the @show@ action of @BookController@ is called 
+* when @AuthorController@ or @PublisherController@ is called
 
 All named arguments accept either a String or a Regex expression. The possible named arguments are:
 


### PR DESCRIPTION
Looked through the Interceptor traits source code and found that any number of matchers can be defined. Added the missing information to the documentation.