### PR TITLE
Fix for Config.groovy being replaced in the section "Content negotitation"

### DIFF
--- a/src/en/guide/theWebLayer/contentNegotiation.gdoc
+++ b/src/en/guide/theWebLayer/contentNegotiation.gdoc
@@ -2,7 +2,36 @@ Grails has built in support for [Content negotiation|http://en.wikipedia.org/wik
 
 h4. Configuring Mime Types
 
-Before you can start dealing with content negotiation you need to tell Grails what content types you wish to support. By default Grails comes configured with a number of different content types within @grails-app/conf/Config.groovy@ using the @grails.mime.types@ setting:
+Before you can start dealing with content negotiation you need to tell Grails what content types you wish to support. By default Grails comes configured with a number of different content types within @grails-app/conf/application.yml@ using the @grails.mime.types@ setting:
+
+{code:java}
+grails:
+    mime:
+        types:
+            all: '*/*'
+            atom: application/atom+xml
+            css: text/css
+            csv: text/csv
+            form: application/x-www-form-urlencoded
+            html: 
+              - text/html
+              - application/xhtml+xml
+            js: text/javascript
+            json:
+              - application/json
+              - text/json
+            multipartForm: multipart/form-data
+            rss: application/rss+xml
+            text: text/plain
+            hal: 
+              - application/hal+json
+              - application/hal+xml
+            xml:
+              - text/xml
+              - application/xml
+{code}
+
+The setting can also be done in @grails-app/conf/application.groovy@ as shown below:
 
 {code:java}
 grails.mime.types = [ // the first one is the default format


### PR DESCRIPTION
Fix for Config.groovy being replaced in the section "Content negotitation"