### PR TITLE
Fix for two heading in traits documentation

### DIFF
--- a/src/en/guide/toc.yml
+++ b/src/en/guide/toc.yml
@@ -183,7 +183,7 @@ theWebLayer:
 traits:
   title: Traits
   traitsprovided:
-    title: Traits Provided
+    title: Traits Provided by Grails
     example:
         title: WebAttributes Trait Example
 webServices:

--- a/src/en/guide/traits/traitsprovided.gdoc
+++ b/src/en/guide/traits/traitsprovided.gdoc
@@ -1,5 +1,3 @@
-h2. Traits Provided By Grails
-
 Grails artefacts are automatically augmented with certain traits at compile time.
 
 h4. Domain Class Traits


### PR DESCRIPTION
https://grails.github.io/grails-doc/latest/guide/traits.html had two headings. Fix for that.