### PR TITLE
Advanced subqueries content section from Gorm grails doc 2.5.0 content has been added to latest GORM documentation

### DIFF
--- a/src/en/guide/GORM/querying/whereQueries.gdoc
+++ b/src/en/guide/GORM/querying/whereQueries.gdoc
@@ -90,6 +90,8 @@ def query = Person.where {
 }
 {code}
 
+
+
 h4. Query Composition
 
 Since the return value of the @where@ method is a [DetachedCriteria|guide:detachedCriteria] instance you can compose new queries from the original query:
@@ -249,6 +251,56 @@ Since the @property@ subquery returns multiple results, the criterion used compa
 Person.where {
     age < property(age).of { lastName == "Simpson" }
 }
+{code}
+
+
+h4.More Advanced Subqueries in GORM
+
+The support for subqueries has been extended. You can now use {code} in {code} with nested subqueries
+
+{code}
+def results = Person.where {
+    firstName in where { age < 18 }.firstName
+}.list()
+{code}
+
+Criteria and where queries can be seamlessly mixed:
+
+{code}
+ def results = Person.withCriteria {
+    notIn "firstName", Person.where { age < 18 }.firstName
+ }
+{code}
+
+Subqueries can be used with projections:
+
+{code}
+def results = Person.where {
+    age > where { age > 18 }.avg('age')
+}
+{code}
+
+Correlated queries that span two domain classes can be used:
+{code}
+    def employees = Employee.where {
+    region.continent in ['APAC', "EMEA"]
+    }.id()
+    def results = Sale.where {
+    employee in employees && total > 100000
+    }.employee.list()
+{code}
+
+And support for aliases (cross query references) using simple variable declarations has been added to where queries:
+{code}
+def query = Employee.where {
+    def em1 = Employee
+    exists Sale.where {
+        def s1 = Sale
+        def em2 = employee
+        return em2.id == em1.id
+    }.id()
+}
+def results = query.list()
 {code}
 
 

--- a/src/en/guide/GORM/querying/whereQueries.gdoc
+++ b/src/en/guide/GORM/querying/whereQueries.gdoc
@@ -254,9 +254,9 @@ Person.where {
 {code}
 
 
-h4.More Advanced Subqueries in GORM
+h4. More Advanced Subqueries in GORM
 
-The support for subqueries has been extended. You can now use {code} in {code} with nested subqueries
+The support for subqueries has been extended. You can now use in  with nested subqueries
 
 {code}
 def results = Person.where {

--- a/src/en/ref/Command Line/create-hibernate-cfg-xml.gdoc
+++ b/src/en/ref/Command Line/create-hibernate-cfg-xml.gdoc
@@ -1,0 +1,23 @@
+h3. Purpose
+
+The create-hibernate-cfg-xml command will create a hibernate.cfg.xml file for custom Hibernate mappings.
+
+h3. Examples
+
+{code}
+grails create-hibernate-cfg-xml
+{code}
+
+h3. Description
+
+Creates a hibernate.cfg.xml file in the grails-app/conf/hibernate directory. You can add <mapping> elements there to reference annotated Java domain classes, classes mapped by hbm.xml files, or hbm.xml files containing <database-object> elements defining custom DDL that's not supported by GORM.
+
+Usage:
+
+{code}
+grails create-hibernate-cfg-xml
+{code}
+
+Fired Events:
+
+* CreatedFile - When the file is created


### PR DESCRIPTION
missing Advanced subqueries content section from Gorm grails doc 2.5.0 content has been added to latest GORM documentation as per https://github.com/grails/grails-doc/issues/266 this issue opened.