### PR TITLE
Fix typo and formatting in flash.gdoc

### DIFF
--- a/src/en/ref/Controllers/flash.gdoc
+++ b/src/en/ref/Controllers/flash.gdoc
@@ -22,4 +22,4 @@ h2. Description
 
 The flash object is a Map (a hash) which you can use to store key value pairs. These values are transparently stored inside the session and then cleared at the end of the next request.
 
-This pattern lets you use HTTP redirects (which is useful for "redirect after post":http://www.theserverside.com/tt/articles/article.tss?l=RedirectAfterPost ) and retain values that can retrieved from the flash object.
+This pattern lets you use HTTP redirects (which is useful for [redirect after post|http://www.theserverside.com/tt/articles/article.tss?l=RedirectAfterPost]) and retain values that can be retrieved from the flash object.


### PR DESCRIPTION
Added "be" to "can be retrieved".

Removed space before closing parenthesis (had to use another syntax for the link).