### PR TITLE
Corrected the url for orm docs. Resolving issue #357.

### DIFF
--- a/resources/doc.properties
+++ b/resources/doc.properties
@@ -90,7 +90,7 @@ api.javax.servlet=http://download.oracle.com/javaee/1.4/api
 api.java.=http://docs.oracle.com/javase/6/docs/api
 api.groovy.=http://docs.groovy-lang.org/docs/latest/html/api
 api.org.codehaus.groovy.grails=http://grails.org/doc/3.0.x/api
-api.grails.=http://grails.org/doc/3.0.x/api
+api.grails.=http://grails.github.io/grails-data-mapping/latest/api
 api.org.grails.=http://grails.org/doc/3.0.x/api
 
 # Regular expression to parse out source code


### PR DESCRIPTION
Changed `api.grails.` to `http://grails.github.io/grails-data-mapping/latest/api`. Issue number #357 can now be closed.