### PR TITLE
Updated docs to use grails version 3.0.4. Resolving issue #351.

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,3 +1,3 @@
-grails.version=3.0.2
+grails.version=3.0.4
 #Let grails.home be empty
 grails.home=


### PR DESCRIPTION
Issue #351 is now resolved and can be closed. We don't need any script and all, as the Grails version is controlled by the value `grails.version` in the file `gradle.properties` I've changed it to 3.0.4 and checked if version is correct in generated docs. It's safe to merge this commit with master.