### PR TITLE
Add form method description

### DIFF
--- a/src/en/ref/Tags/form.gdoc
+++ b/src/en/ref/Tags/form.gdoc
@@ -57,6 +57,7 @@ Attributes
 * @base@ (optional) - Sets the prefix to be added to the link target address, typically an absolute server URL. This overrides the behaviour of the @absolute@ property, if both are specified.
 * @name@ (optional) - A value to use for both the name and id attribute of the form tag
 * @useToken@ (optional) - Set whether to send a token in the request to handle duplicate form submissions. See [Handling Duplicate Form Submissions|guide:formtokens]
+* @method@ (optional) - The form method to use, either @POST@ or @GET@; defaults to @POST@
 
 h2. Source
 


### PR DESCRIPTION
Added description for attribute "method" of tag "form" to the reference
documentation. The description is based on API documentation.