### PR TITLE
Update staticTypeCheckingAndCompilation.gdoc

### DIFF
--- a/src/en/guide/staticTypeCheckingAndCompilation.gdoc
+++ b/src/en/guide/staticTypeCheckingAndCompilation.gdoc
@@ -11,6 +11,6 @@ class MyClass {
 }
 {code}
 
-See [these notes on Groovy static compilation|http://docs.codehaus.org/display/GroovyJSR/GEP+10+-+Static+compilation] for more details on how @CompileStatic@ works and why you might want to use it.
+See [these notes on Groovy static compilation|http://docs.groovy-lang.org/latest/html/documentation/#_static_compilation] for more details on how @CompileStatic@ works and why you might want to use it.
 
 One limitation of using @CompileStatic@ is that when you use it you give up access to the power and flexibility offered by dynamic dispatch.  For example, in Grails you would not be able to invoke a GORM dynamic finder from a class that is marked with @CompileStatic@ because the compiler cannot verify that the dynamic finder method exists, because it doesn't exist at compile time.  It may be that you want to take advantage of Groovy's static compilation benefits without giving up access to dynamic dispatch for Grails specific things like dynamic finders and this is where [grails.compiler.GrailsCompileStatic|api:grails.compiler.GrailsCompileStatic] comes in.  @GrailsCompileStatic@ behaves just like @CompileStatic@ but is aware of certain Grails features and allows access to those specific features to be accessed dynamically.


### PR DESCRIPTION
Fix broken link to groovy docs on static compilation