### PR TITLE
Update test-app command documentation

### DIFF
--- a/src/en/guide/testing.gdoc
+++ b/src/en/guide/testing.gdoc
@@ -96,6 +96,12 @@ This will run the @testLogin@ test in the @SimpleController@ tests. You can spec
 grails test-app some.org.* SimpleController.testLogin BookController
 {code}
 
+If you only wish to re-run failed tests use the -rerun flag
+
+{code}
+grails test-app -rerun
+{code}
+
 h4. Targeting Test Phases
 
 In addition to targeting certain tests, you can also target test _phases._ By default Grails has two testing phases @unit@ and @integration.@

--- a/src/en/ref/Command Line/test-app.gdoc
+++ b/src/en/ref/Command Line/test-app.gdoc
@@ -39,8 +39,8 @@ Tests can also use the suffix of @Test@ instead of @Tests@.
 You can also choose to only run the unit or integration tests:
 
 {code:java}
-grails test-app unit:
-grails test-app integration:
+grails test-app -unit
+grails test-app -integration
 {code}
 
 If you only wish to re-run failed tests use the -rerun flag


### PR DESCRIPTION
Updated the test-app command line documentation to use the Grails 3 syntax for running unit or integration tests only.

Updated the testing section of the guide to mention how to target and re-run failed tests.