### PR TITLE
Update test app docs

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,1 @@
-grails.version=3.0.5
+grails.version=3.0.6

--- a/src/en/guide/testing.gdoc
+++ b/src/en/guide/testing.gdoc
@@ -96,6 +96,12 @@ This will run the @testLogin@ test in the @SimpleController@ tests. You can spec
 grails test-app some.org.* SimpleController.testLogin BookController
 {code}
 
+If you only wish to re-run failed tests use the -rerun flag
+
+{code}
+grails test-app -rerun
+{code}
+
 h4. Targeting Test Phases
 
 In addition to targeting certain tests, you can also target test _phases._ By default Grails has two testing phases @unit@ and @integration.@

--- a/src/en/ref/Command Line/test-app.gdoc
+++ b/src/en/ref/Command Line/test-app.gdoc
@@ -39,8 +39,8 @@ Tests can also use the suffix of @Test@ instead of @Tests@.
 You can also choose to only run the unit or integration tests:
 
 {code:java}
-grails test-app unit:
-grails test-app integration:
+grails test-app -unit
+grails test-app -integration
 {code}
 
 If you only wish to re-run failed tests use the -rerun flag


### PR DESCRIPTION
Updated test-app command documentation to show Grails 3 syntax for running integration or unit tests.

Updated testing guide to add switch to target failed tests.