### PR TITLE
Deleted Duplicate File Differences Header in Upgrading Gdoc

### DIFF
--- a/src/en/guide/upgrading.gdoc
+++ b/src/en/guide/upgrading.gdoc
@@ -21,8 +21,6 @@ Before and after interceptors were removed. So all @beforeInterceptor@ and @afte
 
 h4. File Location Differences
 
-h4. File Location Differences
-
 The location of certain files have changed or been replaced with other files in Grails 3.0. The following table lists old default locations and their respective new locations:
 
 {table}


### PR DESCRIPTION
Trivial Fix for the upgrading.gdoc page.  The File Location Differences header was duplicated on the page when it should only be listed once.