### PR TITLE
Issue #9090 - Grails docs not building the source tags

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,9 +78,9 @@ task migrate(type: grails.doc.gradle.MigrateLegacyDocs)
 
 task publishGuide(type: grails.doc.gradle.PublishGuide, dependsOn: ['apiDocs', 'copyApiDocs']) {
     def searchDirs = project.file(project.grailsHome).listFiles().findAll {
-        new File(it, "src/main/groovy/org/codehaus/groovy/grails").exists()
+        new File(it, "src/main/groovy/org/grails").exists()
     }.collect {
-        new File(it, "src/main/groovy/org/codehaus/groovy/grails")
+        new File(it, "src/main/groovy/org/grails")
     }
 
     // No language setting because we want the English guide to be

--- a/src/en/ref/Tags/fieldError.gdoc
+++ b/src/en/ref/Tags/fieldError.gdoc
@@ -23,3 +23,5 @@ Attributes
 
 h2. Source
 
+{source:tag=ValidationTagLib.fieldError}
+{source}

--- a/src/en/ref/Tags/include.gdoc
+++ b/src/en/ref/Tags/include.gdoc
@@ -54,5 +54,5 @@ Attributes
 
 h2. Source
 
-{source:tag=RenderTagLib.include}
+{source:tag=UrlMappingTagLib.include}
 {source}

--- a/src/en/ref/Tags/paginate.gdoc
+++ b/src/en/ref/Tags/paginate.gdoc
@@ -61,5 +61,5 @@ Attributes
 
 h2. Source
 
-{source:tag=RenderTagLib.paginate}
+{source:tag=UrlMappingTagLib.paginate}
 {source}

--- a/src/en/ref/Tags/sortableColumn.gdoc
+++ b/src/en/ref/Tags/sortableColumn.gdoc
@@ -37,5 +37,5 @@ Attributes
 
 h2. Source
 
-{source:tag=RenderTagLib.sortableColumn}
+{source:tag=UrlMappingTagLib.sortableColumn}
 {source}


### PR DESCRIPTION
Related to grails/grails-core#9323, if that is accepted the other change will be to update the `grails-doc` dependency in the `build.gradle` file.