### PR TITLE
Fix examples with errors.each (fix #360)

### DIFF
--- a/src/en/ref/Domain Classes/hasErrors.gdoc
+++ b/src/en/ref/Domain Classes/hasErrors.gdoc
@@ -10,7 +10,7 @@ h2. Examples
 def b = new Book(title: "The Shining")
 b.validate()
 if (b.hasErrors()) {
-    b.errors.each {
+    b.errors.allErrors.each {
         println it
     }
 }

--- a/src/en/ref/Domain Classes/save.gdoc
+++ b/src/en/ref/Domain Classes/save.gdoc
@@ -23,7 +23,7 @@ The @save@ method returns @null@ if [validation|guide:validation] failed and the
 
 {code:java}
 if (!b.save()) {
-    b.errors.each {
+    b.errors.allErrors.each {
         println it
     }
 }

--- a/src/en/ref/Domain Classes/validate.gdoc
+++ b/src/en/ref/Domain Classes/validate.gdoc
@@ -15,7 +15,7 @@ h2. Examples
 {code:java}
 def b = new Book(title: "The Shining")
 if (!b.validate()) {
-    b.errors.each {
+    b.errors.allErrors.each {
         println it
     }
 }
@@ -26,7 +26,7 @@ def a = new Album(artist: "Genesis", title: "Nursery Cryme", releaseDate: 1971)
 
 // only validate title and releaseDate
 if (!a.validate(["title", "releaseDate"])) {
-    a.errors.each {
+    a.errors.allErrors.each {
         println it
     }
 }


### PR DESCRIPTION
All occurrences of `errors.each` changed to `errors.allErrors.each`,
because the former is incorrect, i.e. does not iterate over errors.