### PR TITLE
Update mockingCollaborators.gdoc

### DIFF
--- a/src/en/guide/testing/unitTesting/mockingCollaborators.gdoc
+++ b/src/en/guide/testing/unitTesting/mockingCollaborators.gdoc
@@ -1,1 +1,1 @@
-The Spock Framework manual has a chapter on [Interaction Based Testing|http://spock-framework.readthedocs.org/en/latest/interaction_based_testing.html] which also explains mocking collaborators.
+The Spock Framework manual has a chapter on [Interaction Based Testing|http://spockframework.github.io/spock/docs/1.0/interaction_based_testing.html] which also explains mocking collaborators.


### PR DESCRIPTION
Fix broken link to spock docs. Couldn't find a way to link direct to the page with "latest" or "current"