### PR TITLE
Update environments.gdoc

### DIFF
--- a/src/en/guide/conf/environments.gdoc
+++ b/src/en/guide/conf/environments.gdoc
@@ -96,7 +96,7 @@ switch (Environment.current) {
 
 h4. Per Environment Bootstrapping
 
-It's often desirable to run code when your application starts up on a per-environment basis. To do so you can use the @grails-app/conf/BootStrap.groovy@ file's support for per-environment execution:
+It's often desirable to run code when your application starts up on a per-environment basis. To do so you can use the @grails-app/init/BootStrap.groovy@ file's support for per-environment execution:
 
 {code}
 def init = { ServletContext ctx ->


### PR DESCRIPTION
Fixed BootStrap.groovy path, that is created in `/grails-app/init` by default, not in `/grails-app/conf`