### PR TITLE
Update Command Line.gdoc

### DIFF
--- a/src/en/ref/Command Line.gdoc
+++ b/src/en/ref/Command Line.gdoc
@@ -11,7 +11,7 @@ grails [environment]* [command name]
 Grails searches in the following directories for Gant scripts to execute:
 
 * @USER_HOME/.grails/scripts@
-* @PROJECT_HOME/scripts@
+* @PROJECT_HOME/src/main/scripts/@
 * @PROJECT_HOME/plugins/*/scripts@
 * @GRAILS_HOME/scripts@
 


### PR DESCRIPTION
Grails won't search in `PROJECT_HOME/scripts/`.
It will search in `PROJECT_HOME/src/main/scripts/`.
At least it's how it worked for me.