### PR TITLE
Improving Testing Documentation

### DIFF
--- a/src/en/guide/testing.gdoc
+++ b/src/en/guide/testing.gdoc
@@ -100,6 +100,20 @@ grails test-app some.org.* SimpleController.testLogin BookController
 In Grails 2.x, adding -rerun as an argument would only run those tests which failed in the previous test-app run. This argument is no longer supported.
 {note}
 
+h4. Debugging
+
+In order to debug your tests via a remote debugger, you can add @--debug-jvm@ after @grails@ in any commands, like so:
+
+{code}
+grails --debug-jvm test-app
+{code}
+
+This will the default Java remote debugging port, 5005, for you to attach a remote debugger from your editor / IDE of choice.
+
+{note}
+This differs from Grails 2.3 and previous, where the @grails-debug@ command existed.
+{note}
+
 h4. Targeting Test Phases
 
 In addition to targeting certain tests, you can also target test _phases._ By default Grails has two testing phases @unit@ and @integration.@

--- a/src/en/guide/testing.gdoc
+++ b/src/en/guide/testing.gdoc
@@ -96,11 +96,9 @@ This will run the @testLogin@ test in the @SimpleController@ tests. You can spec
 grails test-app some.org.* SimpleController.testLogin BookController
 {code}
 
-If you only wish to re-run failed tests use the -rerun flag
-
-{code}
-grails test-app -rerun
-{code}
+{note}
+In Grails 2.x, adding -rerun as an argument would only run those tests which failed in the previous test-app run. This argument is no longer supported.
+{note}
 
 h4. Targeting Test Phases
 

--- a/src/en/guide/testing.gdoc
+++ b/src/en/guide/testing.gdoc
@@ -97,7 +97,7 @@ grails test-app some.org.* SimpleController.testLogin BookController
 {code}
 
 {note}
-In Grails 2.x, adding -rerun as an argument would only run those tests which failed in the previous test-app run. This argument is no longer supported.
+In Grails 2.x, adding @-rerun@ as an argument would only run those tests which failed in the previous test-app run. This argument is no longer supported.
 {note}
 
 h4. Debugging
@@ -108,7 +108,7 @@ In order to debug your tests via a remote debugger, you can add @--debug-jvm@ af
 grails --debug-jvm test-app
 {code}
 
-This will the default Java remote debugging port, 5005, for you to attach a remote debugger from your editor / IDE of choice.
+This will open the default Java remote debugging port, 5005, for you to attach a remote debugger from your editor / IDE of choice.
 
 {note}
 This differs from Grails 2.3 and previous, where the @grails-debug@ command existed.


### PR DESCRIPTION
We've experienced that the -rerun command no longer exists in Grails 3, and think it would be helpful to those looking up testing commands to have the debug instructions made easily available. 

Please let me know how to better phrase / polish these additions and I will happily oblige!