### PR TITLE
Remove remaining context-paths from example URLs, fix stale link

### DIFF
--- a/src/en/guide/async.gdoc
+++ b/src/en/guide/async.gdoc
@@ -1,5 +1,5 @@
 With modern hardware featuring multiple cores, many programming languages have been adding asynchronous, parallel programming APIs, Groovy being no exception.
 
-The excellent [GPars|http://gpars.codehaus.org] project features a whole range of different APIs for asynchronous programming techniques including actors, promises, STM and data flow concurrency.
+The excellent [GPars|https://github.com/GPars/GPars] project features a whole range of different APIs for asynchronous programming techniques including actors, promises, STM and data flow concurrency.
 
 Added Grails 2.3, the Async features of Grails aim to simplify concurrent programming within the framework and include the concept of Promises and a unified event model.

--- a/src/en/guide/scaffolding.gdoc
+++ b/src/en/guide/scaffolding.gdoc
@@ -37,7 +37,7 @@ With this configured, when you start your application the actions and views will
 * save
 * update
 
-A CRUD interface will also be generated. To access this open @http://localhost:8080/app/book@ in a browser.
+A CRUD interface will also be generated. To access this open @http://localhost:8080/book@ in a browser.
 
 Note: The old alternative of defining @scaffold@ property:
 

--- a/src/en/guide/theWebLayer/controllers/commandObjects.gdoc
+++ b/src/en/guide/theWebLayer/controllers/commandObjects.gdoc
@@ -172,7 +172,7 @@ class Widget {
 {code}
 
 {code}
-\$ curl -H "Content-Type: application/json" -d '{"name":"Some Widget","size":"42"}' localhost:8080/myapp/demo/createWidget
+\$ curl -H "Content-Type: application/json" -d '{"name":"Some Widget","size":"42"}' localhost:8080/demo/createWidget
  Name: Some Widget, Size: 42
 ~ \$
 \$ curl -H "Content-Type: application/xml" -d '<widget><name>Some Other Widget</name><size>2112</size></widget>' localhost:8080/bodybind/demo/createWidget

--- a/src/en/guide/webServices/REST/domainResources.gdoc
+++ b/src/en/guide/webServices/REST/domainResources.gdoc
@@ -26,7 +26,7 @@ You can try it out by adding some test data to @BootStrap.groovy@:
     }
 {code}
 
-And then hitting the URL http://localhost:8080/myapp/books/1, which will render the response like:
+And then hitting the URL http://localhost:8080/books/1, which will render the response like:
 
 {code}
 <?xml version="1.0" encoding="UTF-8"?>
@@ -35,7 +35,7 @@ And then hitting the URL http://localhost:8080/myapp/books/1, which will render 
 </book>
 {code}
 
-If you change the URL to @http://localhost:8080/myapp/books/1.json@ you will get a JSON response such as:
+If you change the URL to @http://localhost:8080/books/1.json@ you will get a JSON response such as:
 
 
 {code}
@@ -69,7 +69,7 @@ See the section on [Configuring Mime Types|guide:contentNegotiation] in the user
 Instead of using the file extension in the URI, you can also obtain a JSON response using the ACCEPT header. Here's an example using the Unix @curl@ tool:
 
 {code}
-$ curl -i -H "Accept: application/json" localhost:8080/myapp/books/1
+$ curl -i -H "Accept: application/json" localhost:8080/books/1
 {"id":1,"title":"The Stand"}
 {code}
 
@@ -78,7 +78,7 @@ This works thanks to Grails' [Content Negotiation|guide:contentNegotiation] feat
 You can create a new resource by issuing a @POST@ request:
 
 {code}
-$ curl -i -X POST -H "Content-Type: application/json" -d '{"title":"Along Came A Spider"}' localhost:8080/myapp/books
+$ curl -i -X POST -H "Content-Type: application/json" -d '{"title":"Along Came A Spider"}' localhost:8080/books
 HTTP/1.1 201 Created
 Server: Apache-Coyote/1.1
 ...
@@ -87,7 +87,7 @@ Server: Apache-Coyote/1.1
 Updating can be done with a @PUT@ request:
 
 {code}
-$ curl -i -X PUT -H "Content-Type: application/json" -d '{"title":"Along Came A Spider"}' localhost:8080/myapp/books/1
+$ curl -i -X PUT -H "Content-Type: application/json" -d '{"title":"Along Came A Spider"}' localhost:8080/books/1
 HTTP/1.1 200 OK
 Server: Apache-Coyote/1.1
 ...
@@ -96,7 +96,7 @@ Server: Apache-Coyote/1.1
 Finally a resource can be deleted with @DELETE@ request:
 
 {code}
-$ curl -i -X DELETE localhost:8080/myapp/books/1
+$ curl -i -X DELETE localhost:8080/books/1
 HTTP/1.1 204 No Content
 Server: Apache-Coyote/1.1
 ...

--- a/src/en/guide/webServices/REST/hypermedia/hal.gdoc
+++ b/src/en/guide/webServices/REST/hypermedia/hal.gdoc
@@ -57,7 +57,7 @@ beans = {
 With the bean in place requesting the HAL content type will return HAL:
 
 {code}
-$ curl -i -H "Accept: application/hal+json" http://localhost:8080/myapp/books/1
+$ curl -i -H "Accept: application/hal+json" http://localhost:8080/books/1
 
 HTTP/1.1 200 OK
 Server: Apache-Coyote/1.1
@@ -66,7 +66,7 @@ Content-Type: application/hal+json;charset=ISO-8859-1
 {
   "_links": {
     "self": {
-      "href": "http://localhost:8080/myapp/books/1",
+      "href": "http://localhost:8080/books/1",
       "hreflang": "en",
       "type": "application/hal+json"
     }
@@ -98,7 +98,7 @@ beans = {
 With the bean in place requesting the HAL content type will return HAL:
 
 {code}
-$ curl -i -H "Accept: application/hal+json" http://localhost:8080/myapp/books
+$ curl -i -H "Accept: application/hal+json" http://localhost:8080/books
 HTTP/1.1 200 OK
 Server: Apache-Coyote/1.1
 Content-Type: application/hal+json;charset=UTF-8
@@ -108,7 +108,7 @@ Date: Thu, 17 Oct 2013 02:34:14 GMT
 {
   "_links": {
     "self": {
-      "href": "http://localhost:8080/myapp/books",
+      "href": "http://localhost:8080/books",
       "hreflang": "en",
       "type": "application/hal+json"
     }
@@ -118,7 +118,7 @@ Date: Thu, 17 Oct 2013 02:34:14 GMT
       {
         "_links": {
           "self": {
-            "href": "http://localhost:8080/myapp/books/1",
+            "href": "http://localhost:8080/books/1",
             "hreflang": "en",
             "type": "application/hal+json"
           }
@@ -128,7 +128,7 @@ Date: Thu, 17 Oct 2013 02:34:14 GMT
       {
         "_links": {
           "self": {
-            "href": "http://localhost:8080/myapp/books/2",
+            "href": "http://localhost:8080/books/2",
             "hreflang": "en",
             "type": "application/hal+json"
           }
@@ -138,7 +138,7 @@ Date: Thu, 17 Oct 2013 02:34:14 GMT
       {
         "_links": {
           "self": {
-            "href": "http://localhost:8080/myapp/books/3",
+            "href": "http://localhost:8080/books/3",
             "hreflang": "en",
             "type": "application/hal+json"
           }
@@ -164,7 +164,7 @@ beans = {
 With that in place the rendered HAL will look like the following:
 
 {code}
-$ curl -i -H "Accept: application/hal+json" http://localhost:8080/myapp/books
+$ curl -i -H "Accept: application/hal+json" http://localhost:8080/books
 HTTP/1.1 200 OK
 Server: Apache-Coyote/1.1
 Content-Type: application/hal+json;charset=UTF-8
@@ -174,7 +174,7 @@ Date: Thu, 17 Oct 2013 02:34:14 GMT
 {
   "_links": {
     "self": {
-      "href": "http://localhost:8080/myapp/books",
+      "href": "http://localhost:8080/books",
       "hreflang": "en",
       "type": "application/hal+json"
     }
@@ -184,7 +184,7 @@ Date: Thu, 17 Oct 2013 02:34:14 GMT
       {
         "_links": {
           "self": {
-            "href": "http://localhost:8080/myapp/books/1",
+            "href": "http://localhost:8080/books/1",
             "hreflang": "en",
             "type": "application/hal+json"
           }
@@ -194,7 +194,7 @@ Date: Thu, 17 Oct 2013 02:34:14 GMT
       {
         "_links": {
           "self": {
-            "href": "http://localhost:8080/myapp/books/2",
+            "href": "http://localhost:8080/books/2",
             "hreflang": "en",
             "type": "application/hal+json"
           }
@@ -204,7 +204,7 @@ Date: Thu, 17 Oct 2013 02:34:14 GMT
       {
         "_links": {
           "self": {
-            "href": "http://localhost:8080/myapp/books/3",
+            "href": "http://localhost:8080/books/3",
             "hreflang": "en",
             "type": "application/hal+json"
           }
@@ -254,7 +254,7 @@ In the above example the first bean defines a HAL renderer for a single book ins
 With this in place issuing a request for the new Mime Type returns the necessary HAL:
 
 {code}
-$ curl -i -H "Accept: application/vnd.books.org.book+json" http://localhost:8080/myapp/books/1
+$ curl -i -H "Accept: application/vnd.books.org.book+json" http://localhost:8080/books/1
 
 HTTP/1.1 200 OK
 Server: Apache-Coyote/1.1
@@ -264,7 +264,7 @@ Content-Type: application/vnd.books.org.book+json;charset=ISO-8859-1
 {
   "_links": {
     "self": {
-      "href": "http://localhost:8080/myapp/books/1",
+      "href": "http://localhost:8080/books/1",
       "hreflang": "en",
       "type": "application/vnd.books.org.book+json"
     }
@@ -294,12 +294,12 @@ Which will result in output such as:
 {
   "_links": {
     "self": {
-      "href": "http://localhost:8080/myapp/books/1",
+      "href": "http://localhost:8080/books/1",
       "hreflang": "en",
       "type": "application/vnd.books.org.book+json"
     }
     "publisher": {
-        "href": "http://localhost:8080/myapp/books/1/publisher",
+        "href": "http://localhost:8080/books/1/publisher",
         "hreflang": "en"
     }
   },

--- a/src/en/guide/webServices/REST/hypermedia/vndError.gdoc
+++ b/src/en/guide/webServices/REST/hypermedia/vndError.gdoc
@@ -3,7 +3,7 @@
 By default when a validation error occurs when attempting to POST new resources then the errors object will be sent back allow with a 422 respond code:
 
 {code}
-$ curl -i -H "Accept: application/json"  -H "Content-Type: application/json" -X POST -d "" http://localhost:8080/myapp/books
+$ curl -i -H "Accept: application/json"  -H "Content-Type: application/json" -X POST -d "" http://localhost:8080/books
 
 HTTP/1.1 422 Unprocessable Entity
 Server: Apache-Coyote/1.1
@@ -27,7 +27,7 @@ beans = {
 Then if you alter the client request to accept Vnd.Error you get an appropriate response:
 
 {code}
-$ curl -i -H "Accept: application/vnd.error+json,application/json" -H "Content-Type: application/json" -X POST -d "" http://localhost:8080/myapp/books
+$ curl -i -H "Accept: application/vnd.error+json,application/json" -H "Content-Type: application/json" -X POST -d "" http://localhost:8080/books
 HTTP/1.1 200 OK
 Server: Apache-Coyote/1.1
 Content-Type: application/vnd.error+json;charset=ISO-8859-1

--- a/src/en/guide/webServices/REST/versioningResources.gdoc
+++ b/src/en/guide/webServices/REST/versioningResources.gdoc
@@ -40,7 +40,7 @@ As an alternative Grails supports the passing of an @Accept-Version@ header from
 Then in the client simply pass which version you need using the @Accept-Version@ header:
 
 {code}
-$ curl -i -H "Accept-Version: 1.0" -X GET http://localhost:8080/myapp/books
+$ curl -i -H "Accept-Version: 1.0" -X GET http://localhost:8080/books
 {code}
 
 h4. Versioning using Hypermedia / Mime Types
@@ -86,5 +86,5 @@ class BookController extends RestfulController {
 Then using the @Accept@ header you can specify which version you need using the Mime Type:
 
 {code}
-$ curl -i -H "Accept: application/vnd.books.org.book+json;v=1.0" -X GET http://localhost:8080/myapp/books
+$ curl -i -H "Accept: application/vnd.books.org.book+json;v=1.0" -X GET http://localhost:8080/books
 {code}


### PR DESCRIPTION
There are still a number of examples with context-paths.  

```
http://localhost:8080/myapp/books/1  --->  http://localhost:8080/books/1
```