### PR TITLE
#415 fix UrlMappings example path - Update providingBasicArtefacts.gdoc 

### DIFF
--- a/src/en/guide/plugins/providingBasicArtefacts.gdoc
+++ b/src/en/guide/plugins/providingBasicArtefacts.gdoc
@@ -89,7 +89,7 @@ By default Grails excludes the following files during the packaging process:
 * SCM management files within @\*\*/.svn/\*\*@ and @\*\*/CVS/\*\*@
 
 
-In addition, the default @UrlMappings.groovy@ file is excluded to avoid naming conflicts, however you are free to add a UrlMappings definition under a different name which *will* be included. For example a file called @grails-app/conf/BlogUrlMappings.groovy@ is fine.
+In addition, the default @UrlMappings.groovy@ file is excluded to avoid naming conflicts, however you are free to add a UrlMappings definition under a different name which *will* be included. For example a file called @grails-app/controllers/BlogUrlMappings.groovy@ is fine.
 
 The list of excludes is extensible with the @pluginExcludes@ property:
 


### PR DESCRIPTION
Fixes UrlMappings path, see #415 