### PR TITLE
Fix typo choise -> choice

### DIFF
--- a/src/en/guide/gettingStarted/ide.gdoc
+++ b/src/en/guide/gettingStarted/ide.gdoc
@@ -6,7 +6,7 @@ The community edition can be used for most things, although GSP syntax higlighti
 
 h4. Eclipse
 
-We recommend that users of "Eclipse":http://www.eclipse.org/ looking to develop Grails application take a look at [Groovy/Grails Tool Suite|https://spring.io/tools/ggts], which offers built in support for Grails including automatic classpath management, a GSP editor and quick access to Grails commands. 
+We recommend that users of "Eclipse":http://www.eclipse.org/ looking to develop Grails application take a look at [Groovy/Grails Tool Suite|https://spring.io/tools/ggts], which offers built in support for Grails including automatic classpath management, a GSP editor and quick access to Grails commands.
 
 Like Intellij you can import a Grails 3.0 project using the Gradle project integration.
 
@@ -20,5 +20,5 @@ There are several excellent text editors that work nicely with Groovy and Grails
 
 * A [TextMate bundle|https://github.com/textmate/groovy-grails.tmbundle] exists Groovy / Grails support in [Textmate|http://macromates.com]
 * A [Sublime Text plugin|https://github.com/osoco/sublimetext-grails] can be installed via Sublime Package Control for the [Sublime Text Editor|http://www.sublimetext.com].
-* See [this post|http://www.objectpartners.com/2012/02/21/using-vim-as-your-grails-ide-part-1-navigating-your-project/] for some helpful tips on how to setup VIM as your Grails editor of choise.
+* See [this post|http://www.objectpartners.com/2012/02/21/using-vim-as-your-grails-ide-part-1-navigating-your-project/] for some helpful tips on how to setup VIM as your Grails editor of choice.
 * An [Atom Package|https://atom.io/packages/atom-grails] is available for use with the [Atom editor|https://atom.io]


### PR DESCRIPTION
Fixing a typo in the IDE setup section in Getting Started. 