### PR TITLE
Updated info on the meta tag

### DIFF
--- a/src/en/ref/Tags/meta.gdoc
+++ b/src/en/ref/Tags/meta.gdoc
@@ -7,17 +7,17 @@ Renders application metadata properties.
 h2. Examples
 
 {code:xml}
-Version <g:meta name="app.version"/>
-Built with Grails <g:meta name="app.grails.version"/>
+Version <g:meta name="info.app.version"/>
+Built with Grails <g:meta name="info.app.grails.version"/>
 {code}
 
 h2. Description
 
-Meta properties are populated from the @application.properties@ file, and include the application's version and the Grails version it requires. It can be used to expose some invariant data about your application at runtime. See the Application Metadata section for more details.
+Meta properties are populated from the @gradle.properties@ file, and include the application's version and the Grails version it requires. It can be used to expose some invariant data about your application at runtime. See the Application Metadata section for more details.
 
 Attributes
 
-* @name@ - The name of the metadata property to retrieve, for example "app.version"
+* @name@ - The name of the metadata property to retrieve, preceded by the "info" prefix, for example "info.app.version"
 
 h2. Source
 


### PR DESCRIPTION
The docs on the `meta` gsp tag were for Grails 2, not Grails 3. 