### PR TITLE
Made 3.1 docs like 3.0 docs for meta tags

### DIFF
--- a/src/en/ref/Tags/meta.gdoc
+++ b/src/en/ref/Tags/meta.gdoc
@@ -7,17 +7,17 @@ Renders application metadata properties.
 h2. Examples
 
 {code:xml}
-Version <g:meta name="app.version"/>
-Built with Grails <g:meta name="app.grails.version"/>
+Version <g:meta name="info.app.version"/>
+Built with Grails <g:meta name="info.app.grailsVersion"/>
 {code}
 
 h2. Description
 
-Meta properties are populated from the @application.properties@ file, and include the application's version and the Grails version it requires. It can be used to expose some invariant data about your application at runtime. See the Application Metadata section for more details.
+Meta properties are populated from the @application.yml@ file, as well as the @grails.build.info@ file if it exists, such as in a production environment, and include the application's version and the Grails version it requires. It can be used to expose some invariant data about your application at runtime. See the Application Metadata section for more details.
 
 Attributes
 
-* @name@ - The name of the metadata property to retrieve, for example "app.version"
+* @name@ - The name of the metadata property to retrieve, for example "info.app.version"
 
 h2. Source
 


### PR DESCRIPTION
The docs for the `meta` GSP tag was correct in the 3.0.x docs but not in 3.1.x