### PR TITLE
Add serverPort documentation

### DIFF
--- a/src/en/guide/testing/functionalTesting.gdoc
+++ b/src/en/guide/testing/functionalTesting.gdoc
@@ -47,3 +47,5 @@ class HomeSpec extends GebSpec {
 {code}
 
 If the @applicationClass@ is not specified then the test runtime environment will attempt to locate the application class dynamically which can be problematic in multiproject builds where multiple application classes may be present.
+
+When running the server port by default will be randomly assigned. The @Integration@ annotation adds a property of @serverPort@ to the test class that you can use if you want to know what port the application is running on this isn't needed if you are extending the @GebSpec@ as shown above but can be useful information.


### PR DESCRIPTION
As of Grails 3.1.9 the default port used in a test with @Integration is
random and can be found at serverPort.