### PR TITLE
Updating filters documentation when upgrading application to Grails 3.1

### DIFF
--- a/src/en/guide/upgrading/upgrading3x.gdoc
+++ b/src/en/guide/upgrading/upgrading3x.gdoc
@@ -48,6 +48,8 @@ The Filters plugin was replaced by [Interceptors|guide:interceptors] in Grails 3
 compile 'org.grails:grails-plugin-filters:3.0.12'
 {code}
 
+You would also need to move the filters to any other source directory (e.g. @grails-app/controllers@) as @grails-app/conf@ is not considered a source directory anymore.
+
 h4. Spring Transactional Proxies
 
 Because the @grails.transactional.Transactional@ transform already provides the ability to create transactional services without the need for proxies, traditional support for transactional proxies has been disabled by default.


### PR DESCRIPTION
After some research with the filters plugin support in Grails 3.1 and checking it also in the Slack chat, @burtbeckwith gave me some light and told me that filters shouldn't be in grails-app/conf folder as it is not considered a source folder anymore so we should move the filters to any other source folder, probably recommended grails-app/controllers