### PR TITLE
Added Cloud Deployment with Boxfuse and AWS section

### DIFF
--- a/src/en/guide/deployment/deploymentCloud.gdoc
+++ b/src/en/guide/deployment/deploymentCloud.gdoc
@@ -1,0 +1,39 @@
+Grails apps can be deployed very easily to the cloud.
+
+h3. Boxfuse and Amazon Web Services
+
+[Boxfuse|https://boxfuse.com] turns your Grails executable jar or war into a minimal VM image that can be deployed unchanged either on VirtualBox or on AWS. Boxfuse comes with deep integration for Grails and will use the information from your Grails configuration file to automatically configure ports and health check URLs. Boxfuse leverages this information both for the images it produces as well as for all the resources it provisions (instances, security groups, elastic load balancers, etc).
+
+Make sure you have created a Boxfuse account, connected it to your AWS account, and installed the latest version of the Boxfuse Client.
+
+Deploying your Grails app (packaged as a jar or war) to AWS with Boxfuse is then as simple as executing one command:
+
+{code}
+boxfuse run my-grails-app-1.0.jar -env=prod
+{code}
+
+Boxfuse will create an image for your application, upload it, and then configure and start the necessary resources on AWS:
+
+{code:xml}
+Creating myuser/my-grails-app ...
+Fusing Image for my-grails-app-1.0.jar ...
+Image fused in 00:05.089s (97828 K) -> myuser/my-grails-app:1.0
+Pushing myuser/my-grails-app:1.0 ...
+Verifying myuser/my-grails-app:1.0 ...
+Waiting for AWS to create an AMI for myuser/my-grails-app:1.0 in eu-central-1 (this may take up to 50 seconds) ...
+AMI created in 00:19.095s in eu-central-1 -> ami-fd5b4491
+Creating Elastic IP ...
+Mapping mygrailsapp-myuser.boxfuse.io to 52.29.77.147 ...
+Creating security group boxsg-myuser-prod-my-grails-app-1.0 ...
+Launching t2.micro instance of myuser/my-grails-app:1.0 (ami-fd5b4491) in prod (eu-central-1) ...
+Instance launched in 00:25.707s -> i-2c1daf90
+Waiting for AWS to boot Instance i-2c1daf90 and Payload to start at http://52.59.247.126:8080/health ...
+Payload started in 00:45.567s -> http://52.59.247.126:8080/health
+Remapping Elastic IP 52.29.77.147 to i-2c1daf90 ...
+Waiting 15s for AWS to complete Elastic IP Zero Downtime transition ...
+Deployment completed successfully. myuser/my-grails-app:1.0 is up and running at http://mygrailsapp-myuser.boxfuse.io:8080/
+{code}
+
+Your Grails application should now be up and running on AWS.
+
+There's a [blog post on deploying Grails apps on AWS|https://boxfuse.com/blog/grails-aws] as well as documentation for the [Boxfuse Grails integration|https://boxfuse.com/docs/payloads/grails] on their website that will get you started in minutes.

--- a/src/en/guide/toc.yml
+++ b/src/en/guide/toc.yml
@@ -292,6 +292,7 @@ deployment:
   title: Deployment
   deploymentStandalone: Standalone
   deploymentContainer: Container Deployment (e.g. Tomcat)
+  deploymentCloud: Cloud Deployment (e.g. AWS)
   deploymentTasks: Deployment Configuration Tasks
 contributing:
   title: Contributing to Grails


### PR DESCRIPTION
Boxfuse has first-class support for deploying Grails apps to AWS. With one command (`boxfuse run my-grails-app-1.0.jar -env=prod`), Boxfuse provisions, configures and secures all necessary AWS infrastructure and rolls out your Grails app with zero-downtime blue/green deployments.

Port and healthcheck configuration is inferred directly from Grails' configuration files and all necessary AWS resources are configured accordingly.

We believe this is by far the easiest way for Grails users to get up and running on AWS.

*Disclaimer: I am Boxfuse's founder and CEO*