### PR TITLE
Update integration test documentation for transaction changes

### DIFF
--- a/src/en/guide/testing/integrationTesting.gdoc
+++ b/src/en/guide/testing/integrationTesting.gdoc
@@ -10,7 +10,7 @@ Grails uses the test environment for integration tests and loads the application
 
 h4. Transactions
 
-Integration tests run inside a database transaction by default, which is rolled back at the end of the each test. This means that data saved during a test is not persisted to the database (which is shared across all tests). The default generated integration test template includes the [Rollback|api:grails.transaction.Rollback] annotation:
+Integration test methods run inside their own database transaction by default, which is rolled back at the end of each test method. This means that data saved during a test is not persisted to the database (which is shared across all tests). The default generated integration test template includes the [Rollback|api:grails.transaction.Rollback] annotation:
 
 {code}
 import grails.test.mixin.integration.Integration
@@ -30,11 +30,10 @@ class @artifact.name@Spec extends Specification {
 }
 {code}
 
-The @Rollback@ annotation ensures that each test methods runs in a transaction that is rolled back. Generally this is desirable because you do not want your tests depending on order or application state.
+The @Rollback@ annotation ensures that each test method runs in a transaction that is rolled back. Generally this is desirable because you do not want your tests depending on order or application state.
 
-h4. Using Spring's Rollback annotation
-In Grails 3.0 tests rely on @grails.transaction.Rollback@ annotation to bind the session in integration tests. But with this approach the @setup()@ and @setupSpec()@ method in the test is run prior to the transaction starting hence
-you would see @No Hibernate Session found@ error while running integration test if @setup()@ sets up data and persists them as shown in the below sample:
+In Grails 3.0 tests rely on @grails.transaction.Rollback@ annotation to bind the session in integration tests. Though each test method transaction is rolled back, the @setup()@ method uses a separate transaction that is not rolled back.
+Data will persist to the database and will need to be cleaned up manually if @setup()@ sets up data and persists them as shown in the below sample:
 
 {code}
 import grails.test.mixin.integration.Integration
@@ -46,7 +45,7 @@ import spock.lang.*
 class @artifact.name@Spec extends Specification {
 
     void setup() {
-        // Below line would throw a Hibernate session not found error
+        // Below line would persist and not roll back
         new Book(name: 'Grails in Action').save(flush: true)
     }
 
@@ -57,7 +56,7 @@ class @artifact.name@Spec extends Specification {
 }
 {code}
 
-To make sure the setup logic runs within the transaction you have to move it to be called from the method itself. Similar to usage of @setupData()@ method shown below:
+To automatically roll back setup logic, any persistence operations need to be called from the test method itself so that they are run within the test method's rolled back transaction. Similar to usage of the @setupData()@ method shown below:
 
 {code}
 import grails.test.mixin.integration.Integration
@@ -69,6 +68,7 @@ import spock.lang.*
 class @artifact.name@Spec extends Specification {
 
     void setupData() {
+        // Below line would roll back
         new Book(name: 'Grails in Action').save(flush: true)
     }
 
@@ -82,7 +82,8 @@ class @artifact.name@Spec extends Specification {
 }
 {code}
 
-Another approach could be to use Spring's [@Rollback|http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/test/annotation/Rollback.html] instead.
+h4. Using Spring's Rollback annotation
+Another transactional approach could be to use Spring's [@Rollback|http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/test/annotation/Rollback.html] instead.
 
 {code}
 import grails.test.mixin.integration.Integration


### PR DESCRIPTION
As of v3.0.10, the transactional behavior of integration tests is different than that presented in the [documentation](http://docs.grails.org/latest/guide/testing.html#integrationTesting). Commit [cc2f2ed86d18fded831242d0c8d2d1ee885fc8a5 in grails-core](https://github.com/grails/grails-core/commit/cc2f2ed86d18fded831242d0c8d2d1ee885fc8a5#diff-f87e8a1222b58264b3d2056e39fb6086) introduced the ability to persist objects in the `setup()` method of integration tests via the default `@Rollback` annotation.

That commit essentially wrapped the contents of the `setup()` method in its own transaction that is not rolled back.

This change applies to the 3.1.x and 3.2.x lines as well, I can make a pull request to a different branch if that's more appropriate.