### PR TITLE
--skip-wrapper does not exist in grails 3

### DIFF
--- a/src/en/ref/Command Line/create-app.adoc
+++ b/src/en/ref/Command Line/create-app.adoc
@@ -36,8 +36,6 @@ Arguments:
 * `profile` - The profile to use to create the application
 * `features` - The features to use when creating the application
 * `inplace` - Whether to create the application within the current directory
-* `skip-wrapper` - If set the grailsw wrapper script and support files will not be generated
-
 
 === Description
 
@@ -47,5 +45,5 @@ The `create-app` command is responsible for creating an application. By default 
 Usage:
 [source,groovy]
 ----
-grails create-app <<name>> [--skip-wrapper] [--profile] <<profile name>> [--features] <<FEATURE NAMES>>
+grails create-app <<name>> [--profile] <<profile name>> [--features] <<FEATURE NAMES>>
 ----


### PR DESCRIPTION
Opening against 3.0.x as I think that's how things get merged up? I honestly forget each time.