### PR TITLE
Update unitTestingDomains.adoc

### DIFF
--- a/src/en/guide/testing/unitTesting/unitTestingDomains.adoc
+++ b/src/en/guide/testing/unitTesting/unitTestingDomains.adoc
@@ -45,7 +45,7 @@ class BookControllerSpec extends Specification {
 }
 ----
 
-The example above tests the `SimpleController` class and mocks the behavior of the `Simple` domain class as well. For example consider a typical scaffolded `save` controller action:
+The example above tests the `BookController` class and mocks the behavior of the `Book` domain class as well. For example consider a typical scaffolded `save` controller action:
 
 [source,groovy]
 ----


### PR DESCRIPTION
Wrong Controller and Domain name in example. Change `Simple` to `Book`.