### PR TITLE
Fix quickreference guide links

### DIFF
--- a/resources/doc.properties
+++ b/resources/doc.properties
@@ -97,3 +97,6 @@ api.org.grails.=http://grails.github.io/grails-doc/3.2.x/api
 
 # Regular expression to parse out source code
 source.tag.regex=/\s*?def\s+?[a-zA-Z]+?\s*?=\s*?\{\s*?attrs\s*?,{0,1}\s*?body{0,1}\s*?->.+?/
+
+# Path used to link the guide in the Quick Reference
+guidePath=../../guide

--- a/src/en/ref/Command Line/create-app.adoc
+++ b/src/en/ref/Command Line/create-app.adoc
@@ -42,7 +42,7 @@ Arguments:
 === Description
 
 
-The `create-app` command is responsible for creating an application. By default the command will create an application using the "web" profile. For other available profiles use the link:list-profiles.html[list-profiles] and link:../ref/Command%20Line/profile-info.html[profile-info] commands to find out what profiles are available. For more information on profiles see the <<profiles,Profiles>> section of the user guide.
+The `create-app` command is responsible for creating an application. By default the command will create an application using the "web" profile. For other available profiles use the link:list-profiles.html[list-profiles] and link:profile-info.html[profile-info] commands to find out what profiles are available. For more information on profiles see the link:${guidePath}/profiles.html[Profiles] section of the user guide.
 
 Usage:
 [source,java]

--- a/src/en/ref/Command Line/create-app.adoc
+++ b/src/en/ref/Command Line/create-app.adoc
@@ -42,7 +42,7 @@ Arguments:
 === Description
 
 
-The `create-app` command is responsible for creating an application. By default the command will create an application using the "web" profile. For other available profiles use the link:list-profiles.html[list-profiles] and link:profile-info.html[profile-info] commands to find out what profiles are available. For more information on profiles see the link:${guidePath}/profiles.html[Profiles] section of the user guide.
+The `create-app` command is responsible for creating an application. By default the command will create an application using the "web" profile. For other available profiles use the link:list-profiles.html[list-profiles] and link:profile-info.html[profile-info] commands to find out what profiles are available. For more information on profiles see the link:{guidePath}/profiles.html[Profiles] section of the user guide.
 
 Usage:
 [source,java]

--- a/src/en/ref/Command Line/create-app.adoc
+++ b/src/en/ref/Command Line/create-app.adoc
@@ -42,7 +42,7 @@ Arguments:
 === Description
 
 
-The `create-app` command is responsible for creating an application. By default the command will create an application using the "web" profile. For other available profiles use the link:../ref/Command%20Line/list-profiles.html[list-profiles] and link:../ref/Command%20Line/profile-info.html[profile-info] commands to find out what profiles are available. For more information on profiles see the <<profiles,Profiles>> section of the user guide.
+The `create-app` command is responsible for creating an application. By default the command will create an application using the "web" profile. For other available profiles use the link:list-profiles.html[list-profiles] and link:../ref/Command%20Line/profile-info.html[profile-info] commands to find out what profiles are available. For more information on profiles see the <<profiles,Profiles>> section of the user guide.
 
 Usage:
 [source,java]

--- a/src/en/ref/Command Line/create-controller.adoc
+++ b/src/en/ref/Command Line/create-controller.adoc
@@ -18,11 +18,11 @@ grails create-controller org.bookstore.book
 
 Creates a new controller with an empty default action. The argument is optional, but if you don't include it the command will ask you for the name of the controller.
 
-A <<controllers,controller>> is responsible for handling incoming web requests and performing actions such as redirects, rendering views and so on.
+A link:{guidePath}/theWebLayer.html#controllers[controller] is responsible for handling incoming web requests and performing actions such as redirects, rendering views and so on.
 
 The name of the controller can include a Java package, such as `org.bookstore` in the final example above, but if one is not provided a default is used. So the second example will create the file `grails-app/controllers/<appname>/BookController.groovy` whereas the last one will create `grails-app/controllers/org/bookstore/BookController.groovy` directory. Note that the first letter of the controller name is always upper-cased when determining the class name.
 
-If you want the command to default to a different package for controllers, provide a value for `grails.project.groupId` in the <<config,runtime configuration>>.
+If you want the command to default to a different package for controllers, provide a value for `grails.project.groupId` in the link:{guidePath}/conf.html#config[runtime configuration].
 
 Note that this command is just for convenience and you can also create controllers in your favourite text editor or IDE if you choose.
 

--- a/src/en/ref/Command Line/create-domain-class.adoc
+++ b/src/en/ref/Command Line/create-domain-class.adoc
@@ -19,11 +19,11 @@ grails create-domain-class org.bookstore.Book
 
 Creates a domain class for the given base name. For example, for a base name "org.bookstore.Book" a domain class called `Book` will be created in the `grails-app/domain/org/bookstore` directory. The argument is optional, but if you don't include it the command will ask you for the name of the domain class.
 
-A domain class represents the core model behind in your application and is typically mapped onto database tables. For more information on domain models in Grails refer to the chapter on link:GORM.html[GORM] in the user guide.
+A domain class represents the core model behind in your application and is typically mapped onto database tables. For more information on domain models in Grails refer to the chapter on link:{guidePath}/GORM.html[GORM] in the user guide.
 
 The exact behaviour of the command depends on the argument you pass. If you don't specify a package (like "org.bookstore" in the example), then the name of the application will be used as the package. So if the application name is "bookstore" and you run `create-domain-class Book`, then the command will create the file `grails-app/domain/bookstore/Book.groovy`. Also, if you don't give your domain class an initial capital letter, it will be capitalized for you. So an argument of "org.bookstore.book" will result in a domain class called `Book`.
 
-If you want the command to default to a different package for domain classes, provide a value for `grails.project.groupId` in the <<config,runtime configuration>>.
+If you want the command to default to a different package for domain classes, provide a value for `grails.project.groupId` in the link:{guidePath}/conf.html#config[runtime configuration].
 
 Note that this command is just for convenience and you can also create domain classes in your favourite text editor or IDE if you choose.
 

--- a/src/en/ref/Command Line/create-script.adoc
+++ b/src/en/ref/Command Line/create-script.adoc
@@ -51,4 +51,4 @@ testApp()
 
 Code generation can be performed using the http://docs.grails.org/latest/api/org/grails/cli/profile/commands/templates/TemplateRenderer.html[TemplateRenderer API]
 
-For more information, see the section on <<commandLine,creating custom scripts>>.
+For more information, see the section on link:{guidePath}/commandLine.html#creatingCustomScripts[creating custom scripts].

--- a/src/en/ref/Command Line/create-service.adoc
+++ b/src/en/ref/Command Line/create-service.adoc
@@ -17,7 +17,7 @@ grails create-service org.bookstore.Book
 
 Creates a service for the given base name. The argument is optional, but if you don't include it the command will ask you for the name of the service.
 
-A <<services,service>> encapsulates business logic and is delegated to by controllers to perform the core logic of a Grails application.
+A link:{guidePath}/services.html[service] encapsulates business logic and is delegated to by controllers to perform the core logic of a Grails application.
 
 The name of the service can include a Java package, such as `org.bookstore` in the final example above, but if one is not provided a default is used. So the second example will create the file `grails-app/service/<appname>/BookService.groovy` whereas the last one will create `grails-app/services/org/bookstore/BookService.groovy` directory. Note that the first letter of the service name is always upper-cased when determining the class name.
 

--- a/src/en/ref/Command Line/create-taglib.adoc
+++ b/src/en/ref/Command Line/create-taglib.adoc
@@ -17,7 +17,7 @@ grails create-taglib org.bookstore.Book
 
 Creates a tag library for the given base name. The argument is optional, but if you don't include it the command will ask you for the name of the tag library.
 
-A <<taglibs,tag library>> is a "view helper" that in MVC terms helps the view with rendering by providing a set of reusable tags.
+A link:{guidePath}/theWebLayer.html#taglibs[tag library] is a "view helper" that in MVC terms helps the view with rendering by providing a set of reusable tags.
 
 The name of the tag library can include a Java package, such as `org.bookstore` in the final example above, but if one is not provided a default is used. So the second example will create the file `grails-app/taglibs/<appname>/BookTagLib.groovy` whereas the last one will create `grails-app/taglibs/org/bookstore/BookTagLib.groovy` directory. Note that the first letter of the tag library name is always upper-cased when determining the class name.
 

--- a/src/en/ref/Command Line/list-plugins.adoc
+++ b/src/en/ref/Command Line/list-plugins.adoc
@@ -45,4 +45,4 @@ Lists the plugins that are installable. Note: This command can take a while to e
 * scaffolding
 ----
 
-If you require more info about a plugin you can use the link:../ref/Command%20Line/plugin-info.html[plugin-info] command.
+If you require more info about a plugin you can use the link:plugin-info.html[plugin-info] command.

--- a/src/en/ref/Command Line/list-profiles.adoc
+++ b/src/en/ref/Command Line/list-profiles.adoc
@@ -41,4 +41,4 @@ Lists the profiles that are available. Note: This command can take a while to ex
 * web-plugin - Profile for Plugins designed for Web applications
 ----
 
-If you require more info about a profile you can use the link:../ref/Command%20Line/profile-info.html[profile-info] command.
+If you require more info about a profile you can use the link:profile-info.html[profile-info] command.

--- a/src/en/ref/Command Line/test-app.adoc
+++ b/src/en/ref/Command Line/test-app.adoc
@@ -60,4 +60,4 @@ If you only wish to re-run failed tests use the -rerun flag
 grails test-app -rerun
 ----
 
-See the link:testing.html[Testing] section for examples on how to combine the different options to target tests.
+See the link:{guidePath}/testing.html[Testing] section for examples on how to combine the different options to target tests.

--- a/src/en/ref/Constraints.adoc
+++ b/src/en/ref/Constraints.adoc
@@ -18,7 +18,7 @@ class User {
 }
 ----
 
-Refer to the user guide topic on link:validation.html#constraints[Constraints] for more information.
+Refer to the user guide topic on link:{guidePath}validation.html#constraints[Constraints] for more information.
 
 
 === Global Constraints

--- a/src/en/ref/Constraints/bindable.adoc
+++ b/src/en/ref/Constraints/bindable.adoc
@@ -62,7 +62,7 @@ assert 42.0 == employee.salary
 
 Statically typed instance properties are bindable by default.  Properties which are not bindable by default are those related to transient fields, dynamically typed properties and static properties.
 
-See the link:theWebLayer.html#dataBinding[data binding] section for more details on data binding.
+See the link:{guidePath}/theWebLayer.html#dataBinding[data binding] section for more details on data binding.
 
 NOTE: The bindable constraint must be assigned a literal boolean value.  Dynamic expressions are not valid values for the bindable constraint.  The value must be the literal `true` or `false`.
 

--- a/src/en/ref/Constraints/blank.adoc
+++ b/src/en/ref/Constraints/blank.adoc
@@ -25,4 +25,4 @@ Set to `false` if a string value cannot be blank.
 
 Error Code: `className.propertyName.blank`
 
-NOTE: If the string is `null`, it won't validate with `blank: true`. In this case, set the link:../ref/Constraints/nullable.html[nullable] constraint to `true`.
+NOTE: If the string is `null`, it won't validate with `blank: true`. In this case, set the link:nullable.html[nullable] constraint to `true`.

--- a/src/en/ref/Constraints/nullable.adoc
+++ b/src/en/ref/Constraints/nullable.adoc
@@ -27,7 +27,7 @@ This constraint influences http://gorm.grails.org/6.0.x/hibernate/manual/index.h
 
 Error Code: `className.propertyName.nullable`
 
-NOTE: Web requests resulting from form submissions will have blank strings, not `null`, for input fields that have no value. Keep this in mind when doing mass property binding to properties that are not nullable.  The default behavior is such that a blank string will not validate for `nullable: false` since the data binder will convert blank strings to null.  This includes empty strings and blank strings.  A blank string is any string such that the `trim()` method returns an empty string.  To turn off the conversion of empty strings to null set the `grails.databinding.convertEmptyStringsToNull` property to `false` in `application.groovy`. See the link:theWebLayer.html#dataBinding[data binding] section for more details on data binding.
+NOTE: Web requests resulting from form submissions will have blank strings, not `null`, for input fields that have no value. Keep this in mind when doing mass property binding to properties that are not nullable.  The default behavior is such that a blank string will not validate for `nullable: false` since the data binder will convert blank strings to null.  This includes empty strings and blank strings.  A blank string is any string such that the `trim()` method returns an empty string.  To turn off the conversion of empty strings to null set the `grails.databinding.convertEmptyStringsToNull` property to `false` in `application.groovy`. See the link:{guidePath}/theWebLayer.html#dataBinding[data binding] section for more details on data binding.
 
 [source,java]
 ----

--- a/src/en/ref/Constraints/size.adoc
+++ b/src/en/ref/Constraints/size.adoc
@@ -23,7 +23,7 @@ children size: 5..15
 
 Sets the size of a collection, a number property, or String length.
 
-NOTE: Currently this constraint cannot be used in addition to link:../ref/Constraints/blank.html[blank] or link:../ref/Constraints/nullable.html[nullable]. Use a custom validator for these combinations.
+NOTE: Currently this constraint cannot be used in addition to link:blank.html[blank] or link:nullable.html[nullable]. Use a custom validator for these combinations.
 
 This constraint influences http://gorm.grails.org/6.0.x/hibernate/manual/index.html#constraints[schema generation].
 

--- a/src/en/ref/Controllers.adoc
+++ b/src/en/ref/Controllers.adoc
@@ -2,7 +2,7 @@
 === Controller Usage
 
 
-A controller fulfills the C in the Model View Controller (MVC) pattern and is responsible for handling web requests. In Grails a controller is a class with a name that ends in the convention "Controller" and lives in the `grails-app/controllers` directory. A controller can be created with the link:../ref/Command%20Line/create-controller.html[create-controller] command:
+A controller fulfills the C in the Model View Controller (MVC) pattern and is responsible for handling web requests. In Grails a controller is a class with a name that ends in the convention "Controller" and lives in the `grails-app/controllers` directory. A controller can be created with the link:../Command%20Line/create-controller.html[create-controller] command:
 
 [source,java]
 ----
@@ -25,4 +25,4 @@ class HelloController {
 
 Each action in the controller is a method or a Closure and it has access to a number of implicit variables and methods.
 
-Refer to the user guide topic on <<controllers,Controllers>> for more information.
+Refer to the user guide topic on link:{guidePath}/theWebLayer.html#controllers[Controllers] for more information.

--- a/src/en/ref/Controllers/bindData.adoc
+++ b/src/en/ref/Controllers/bindData.adoc
@@ -37,12 +37,12 @@ Usage: `bindData(target, params, includesExcludes*, prefix*)`
 Arguments:
 
 * `target` - The target object to bind to
-* `params` - A `Map` of source parameters, often the link:../ref/Controllers/params.html[params] object when used in a controller
+* `params` - A `Map` of source parameters, often the link:params.html[params] object when used in a controller
 * `includesExcludes` - (Optional) A map with 'include' and/or 'exclude' lists containing the names of properties to either include or exclude.
 * `prefix` - (Optional) A string representing a prefix to use to filter parameters. The method will automatically append a '.' when matching the prefix to parameters, so you can use 'author' to filter for parameters such as 'author.name'.
 
-NOTE: Note that if an empty List or no List is provided as a value for the `include` parameter then all statically typed instance properties will be subject to binding if they are not explicitly excluded. See the link:../ref/Constraints/bindable.html[bindable] constraint documentation for more information on how to control what is bindable and what is not.
+NOTE: Note that if an empty List or no List is provided as a value for the `include` parameter then all statically typed instance properties will be subject to binding if they are not explicitly excluded. See the link:../Constraints/bindable.html[bindable] constraint documentation for more information on how to control what is bindable and what is not.
 
 The underlying implementation uses Spring's Data Binding framework. If the target is a domain class, type conversion errors are stored in the `errors` property of the domain class.
 
-Refer to the section on link:theWebLayer.html#dataBinding[data binding] in the user guide for more information.
+Refer to the section on link:{guidePath}/theWebLayer.html#dataBinding[data binding] in the user guide for more information.

--- a/src/en/ref/Controllers/errors.adoc
+++ b/src/en/ref/Controllers/errors.adoc
@@ -52,4 +52,4 @@ class DemoController {
 
 The `errors` property is used by Grails while processing a request.  Errors are generated when a type conversion happens while processing action parameters or if an exception is thrown while trying to retrieve a domain class command object from the database.
 
-See <<ref-controllers-hasErrors,hasErrors>>.
+See link:hasErrors.html[hasErrors].

--- a/src/en/ref/Controllers/hasErrors.adoc
+++ b/src/en/ref/Controllers/hasErrors.adoc
@@ -26,4 +26,4 @@ class DemoController {
 }
 ----
 
-See <<ref-controllers-errors,errors>>.
+See link:errors.html[errors]

--- a/src/en/ref/Controllers/namespace.adoc
+++ b/src/en/ref/Controllers/namespace.adoc
@@ -54,4 +54,4 @@ class AdminController {
 }
 ----
 
-See the <<namespacedControllers,namespaced controllers>> docs for more information.
+See the link:{guidePath}/theWebLayer.html#namespacedControllers[namespaced controllers] docs for more information.

--- a/src/en/ref/Controllers/params.adoc
+++ b/src/en/ref/Controllers/params.adoc
@@ -22,7 +22,7 @@ class BookController {
 }
 ----
 
-To perform data binding (see link:theWebLayer.html#dataBinding[data binding] in the user guide):
+To perform data binding (see link:{guidePath}/theWebLayer.html#dataBinding[data binding] in the user guide):
 
 [source,groovy]
 ----
@@ -35,7 +35,7 @@ def save() {
 === Description
 
 
-The standard Servlet API provides access to parameters with the `HttpServletRequest` object. Although Grails provides the same capability through the link:../ref/Controllers/request.html[request] object, it goes a bit further by providing a mutable map of request parameters called `params`.
+The standard Servlet API provides access to parameters with the `HttpServletRequest` object. Although Grails provides the same capability through the link:request.html[request] object, it goes a bit further by providing a mutable map of request parameters called `params`.
 
 The `params` object can be indexed into using the array index operator or de-reference operator, so given the URL `/hello?foo=bar` you can access `foo` with
 
@@ -43,7 +43,7 @@ The `params` object can be indexed into using the array index operator or de-ref
 println params.foo
 ----
 
-The params object can also be used to bind request parameters onto the properties of a domain class using either the constructor or the link:../ref/Domain%20Classes/properties.html[properties] property:
+The params object can also be used to bind request parameters onto the properties of a domain class using either the constructor or the link:../Domain%20Classes/properties.html[properties] property:
 
 [source,groovy]
 ----
@@ -52,4 +52,4 @@ book = Book.get(1)
 book.properties = params
 ----
 
-For further reading see link:theWebLayer.html#dataBinding[data binding] in the user guide.
+For further reading see link:{guidePath}/theWebLayer.html#dataBinding[data binding] in the user guide.

--- a/src/en/ref/Controllers/request.adoc
+++ b/src/en/ref/Controllers/request.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-The <<ref-servlet-api-request,request>> object is an instance of the Servlet API's http://docs.oracle.com/javaee/1.4/api/javax/servlet/http/HttpServletRequest.html[HttpServletRequest] class.
+The link:../Servlet%20API/request.html[request] object is an instance of the Servlet API's http://docs.oracle.com/javaee/1.4/api/javax/servlet/http/HttpServletRequest.html[HttpServletRequest] class.
 
 
 === Examples
@@ -29,4 +29,4 @@ class BookController {
 
 The http://docs.oracle.com/javaee/1.4/api/javax/servlet/http/HttpServletRequest.html[HttpServletRequest] class is useful for, amongst other things, obtaining request headers, storing request scoped attributes and establishing information about the client. Refer to the Servlet API's javadocs for further information.
 
-NOTE: The additional methods added to the <<ref-servlet-api-request,request>> object are documented in the Grails Servlet API reference guide
+NOTE: The additional methods added to the link:../Servlet%20API/request.html[request] object are documented in the Grails Servlet API reference guide

--- a/src/en/ref/Controllers/respond.adoc
+++ b/src/en/ref/Controllers/respond.adoc
@@ -25,7 +25,7 @@ respond Book.get(1), formats: ['xml', 'json']
 === Description
 
 
-The respond method uses link:theWebLayer.html#contentNegotiation[Content Negotiation] to respond with the most appropriate content type. See the documentation on <<REST,REST support>> for more information.
+The respond method uses link:{guidePath}/theWebLayer.html#contentNegotiation[Content Negotiation] to respond with the most appropriate content type. See the documentation on <<REST,REST support>> for more information.
 
 Parameters:
 

--- a/src/en/ref/Controllers/response.adoc
+++ b/src/en/ref/Controllers/response.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-The <<ref-servlet-api-response,response>> object is an instance of the Servlet API's http://docs.oracle.com/javaee/1.4/api/javax/servlet/http/HttpServletResponse.html[HttpServletResponse] class.
+The link:../Servlet%20API/response.html[response] object is an instance of the Servlet API's http://docs.oracle.com/javaee/1.4/api/javax/servlet/http/HttpServletResponse.html[HttpServletResponse] class.
 
 
 === Examples
@@ -28,4 +28,4 @@ class BookController {
 
 The Servlet API's `HttpServletResponse` class can be used within Grails to perform all typical activities such as writing out binary data, writing directly to the response and sending error response codes to name but a few. Refer to the documentation on the http://docs.oracle.com/javaee/1.4/api/javax/servlet/http/HttpServletResponse.html[HttpServletResponse] class in the Servlet API for more information.
 
-NOTE: The additional methods added to the <<ref-servlet-api-response,response>> object are documented in the Grails Servlet API reference guide
+NOTE: The additional methods added to the link:../Servlet%20API/response.html[response] object are documented in the Grails Servlet API reference guide

--- a/src/en/ref/Controllers/responseFormats.adoc
+++ b/src/en/ref/Controllers/responseFormats.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-Statically defines the supported response formats used by the link:../ref/Controllers/respond.html[respond] method.
+Statically defines the supported response formats used by the link:respond.html[respond] method.
 
 
 === Examples
@@ -27,5 +27,5 @@ class BookController {
 === Description
 
 
-The `responseFormats` property is used to define the response formats supported by a controller and in turn used by the `respond` method. The `respond` method uses link:theWebLayer.html#contentNegotiation[Content Negotiation] to respond with the most appropriate content type. See the documentation on <<REST,REST support>> for more information.
+The `responseFormats` property is used to define the response formats supported by a controller and in turn used by the `respond` method. The `respond` method uses link:{guidePath}/theWebLayer.html#contentNegotiation[Content Negotiation] to respond with the most appropriate content type. See the documentation on link:{guidePath}/webServices.html#REST[REST support] for more information.
 

--- a/src/en/ref/Controllers/scope.adoc
+++ b/src/en/ref/Controllers/scope.adoc
@@ -33,4 +33,4 @@ This behaviour can be set for an individual controller by specifying a `scope` a
 * `session` - One controller is created for the scope of a user session
 * `singleton` - Only one instance of the controller ever exists (recommended for actions as methods)
 
-See <<controllersAndScopes,Controllers and Scopes>> in the user guide for more information.
+See link:{guidePath}/theWebLayer.html#controllersAndScopes[Controllers and Scopes] in the user guide for more information.

--- a/src/en/ref/Controllers/servletContext.adoc
+++ b/src/en/ref/Controllers/servletContext.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-The <<ref-servlet-api-servletContext,servletContext>> object is an instance of the Servlet API's http://docs.oracle.com/javaee/1.4/api/javax/servlet/ServletContext.html[ServletContext] class.
+The link:../Servlet%20API/servletContext.html[servletContext]  object is an instance of the Servlet API's http://docs.oracle.com/javaee/1.4/api/javax/servlet/ServletContext.html[ServletContext] class.
 
 
 === Examples
@@ -35,4 +35,4 @@ class BookController {
 
 The Servlet API's http://docs.oracle.com/javaee/1.4/api/javax/servlet/ServletContext.html[ServletContext] is useful for, amongst other things, storing global application attributes, reading local server resources and establishing information about the servlet container.
 
-NOTE: Grails adds additional methods to the standard Servlet API's <<ref-servlet-api-servletContext,servletContext>> object. See link for details.
+NOTE: Grails adds additional methods to the standard Servlet API's link:../Servlet%20API/servletContext.html[servletContext] object. See link for details.

--- a/src/en/ref/Controllers/session.adoc
+++ b/src/en/ref/Controllers/session.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-The <<ref-servlet-api-session,session>> object is an instance of the Servlet API's http://docs.oracle.com/javaee/1.4/api/javax/servlet/http/HttpSession.html[HttpSession] class.
+The link:../Servlet%20API/session.html[session] object is an instance of the Servlet API's http://docs.oracle.com/javaee/1.4/api/javax/servlet/http/HttpSession.html[HttpSession] class.
 
 
 === Examples
@@ -32,4 +32,4 @@ class UserController {
 
 The http://docs.oracle.com/javaee/1.4/api/javax/servlet/http/HttpSession.html[HttpSession] class is useful for associated session data with a client.
 
-NOTE: The additional methods added to the <<ref-servlet-api-session,session>> object are documented in the Grails Servlet API reference guide
+NOTE: The additional methods added to the link:../Servlet%20API/session.html[session] object are documented in the Grails Servlet API reference guide

--- a/src/en/ref/Controllers/withForm.adoc
+++ b/src/en/ref/Controllers/withForm.adoc
@@ -25,7 +25,7 @@ withForm {
 === Description
 
 
-The `withForm` method requires the use of the `useToken` attribute in a link:../ref/Tags/form.html[form]
+The `withForm` method requires the use of the `useToken` attribute in a link:../Tags/form.html[form]
 
 [source,xml]
 ----
@@ -43,4 +43,4 @@ withForm {
 }
 ----
 
-See <<formtokens,Handling Duplicate Form Submissions>> for more information.
+See link:{guidePath}/theWebLayer.html#formtokens[Handling Duplicate Form Submissions] for more information.

--- a/src/en/ref/Controllers/withFormat.adoc
+++ b/src/en/ref/Controllers/withFormat.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-Renders different responses based on the incoming request `Accept` header, format parameter or URI extension. See link:theWebLayer.html#contentNegotiation[Content Negotiation] for more information.
+Renders different responses based on the incoming request `Accept` header, format parameter or URI extension. See link:{guidePath}/theWebLayer.html#contentNegotiation[Content Negotiation] for more information.
 
 
 === Examples
@@ -45,7 +45,7 @@ withFormat {
 }
 ----
 
-Here we invoke three methods called `html`, `js` and `xml` that use mime type names configured in `grails-app/conf/application.groovy` (See link:theWebLayer.html#contentNegotiation[Content Negotiation] for more information). The call to `html` accepts a model (a Map) which is passed on to the view. Grails searches for a view called `grails-app/views/book/list.html.gsp` and if that is not found fallback to `grails-app/views/book/list.gsp`.
+Here we invoke three methods called `html`, `js` and `xml` that use mime type names configured in `grails-app/conf/application.groovy` (See link:{guidePath}/theWebLayer.html#contentNegotiation[Content Negotiation] for more information). The call to `html` accepts a model (a Map) which is passed on to the view. Grails searches for a view called `grails-app/views/book/list.html.gsp` and if that is not found fallback to `grails-app/views/book/list.gsp`.
 
 Note that the order of the types is significant if the request format is "all" or if more than one content type has the same "q" rating in the accept header. In the former case, the first type handler in the block is executed ("html" in the short example above). The latter case is more confusing because it only holds if there is more than one content type with the highest "q" rating for which you have a type handler *and* you have more than one type handler matching that "q" rating. For example if the request has "text/html" and "application/xml" with a "q" rating of 1.0, then this code:
 

--- a/src/en/ref/Domain Classes.adoc
+++ b/src/en/ref/Domain Classes.adoc
@@ -2,7 +2,7 @@
 === Domain Class Usage
 
 
-A domain class fulfills the M in the Model View Controller (MVC) pattern and represents a persistent entity that is mapped onto an underlying database table. In Grails a domain is a class that lives in the `grails-app/domain` directory. A domain class can be created with the link:../ref/Command%20Line/create-domain-class.html[create-domain-class] command:
+A domain class fulfills the M in the Model View Controller (MVC) pattern and represents a persistent entity that is mapped onto an underlying database table. In Grails a domain is a class that lives in the `grails-app/domain` directory. A domain class can be created with the link:../Command%20Line/create-domain-class.html[create-domain-class] command:
 
 [source,java]
 ----
@@ -34,6 +34,6 @@ One limitation of the default table naming scheme is that it is problematic to h
 grails.gorm.table.prefix.enabled = true
 ----
 
-Refer to the <<conf,configuration>> section of more details on defining configuration options.
+Refer to the link:{guidePath}/conf.html[configuration] section of more details on defining configuration options.
 
-Refer to the user guide section on link:GORM.html[GORM] for more information.
+Refer to the user guide section on link:{guidePath}/GORM.html[GORM] for more information.

--- a/src/en/ref/Domain Classes/constraints.adoc
+++ b/src/en/ref/Domain Classes/constraints.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-Allows the definition of declarative validation constraints. See link:validation.html[validation] in the user guide.
+Allows the definition of declarative validation constraints. See link:{guidePath}/validation.html[validation] in the user guide.
 
 
 === Examples
@@ -30,7 +30,7 @@ class Book {
 === Description
 
 
-Constraints are defined using the declarative constraints DSL as described in the link:validation.html[validation] section of the user guide. Once evaluated, validation can be applied through the use of the link:../ref/Domain%20Classes/validate.html[validate] method:
+Constraints are defined using the declarative constraints DSL as described in the link:{guidePath}/validation.html[validation] section of the user guide. Once evaluated, validation can be applied through the use of the link:../Domain%20Classes/validate.html[validate] method:
 
 [source,java]
 ----

--- a/src/en/ref/Domain Classes/errors.adoc
+++ b/src/en/ref/Domain Classes/errors.adoc
@@ -30,7 +30,7 @@ else {
 === Description
 
 
-The `errors` property is used by Grails during link:theWebLayer.html#dataBinding[data binding] to store type conversion errors and during link:validation.html[validation] when calling the link:../ref/Domain%20Classes/validate.html[validate] or link:../ref/Domain%20Classes/save.html[save] methods.
+The `errors` property is used by Grails during link:{guidePath}/theWebLayer.html#dataBinding[data binding] to store type conversion errors and during link:{guidePath}validation.html[validation] when calling the link:validate.html[validate] or link:save.html[save] methods.
 
 You can also add your own errors using the http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/validation/Errors#reject(java/lang/String).html[reject] and http://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/validation/Errors#rejectValue(java/lang/String,%20java/lang/String).html[rejectValue] methods:
 

--- a/src/en/ref/Domain Classes/findAll.adoc
+++ b/src/en/ref/Domain Classes/findAll.adoc
@@ -93,7 +93,7 @@ Book.findAll(Closure whereCriteria)
 Book.findAll(Map queryParams, Closure whereCriteria)
 ----
 
-NOTE: If you have a join in your HQL, the method will return a `List` of `Array`s containing domain class instances. You may wish to use link:../ref/Domain%20Classes/executeQuery.html[executeQuery] in this case so you have more flexibility in specifying what gets returned.
+NOTE: If you have a join in your HQL, the method will return a `List` of `Array`s containing domain class instances. You may wish to use link:executeQuery.html[executeQuery] in this case so you have more flexibility in specifying what gets returned.
 
 Parameters:
 

--- a/src/en/ref/Domain Classes/findOrCreateBy.adoc
+++ b/src/en/ref/Domain Classes/findOrCreateBy.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-Dynamic method that uses the properties of the domain class to create query method expressions that return the first result of the query. This method behaves like link:../ref/Domain%20Classes/findBy.html[findBy] except that it will never return `null`.  If a matching instance cannot be found then a new instance will be created and returned, populated with values represented in the query parameters. The difference between this method and link:../ref/Domain%20Classes/findOrSaveBy.html[findOrSaveBy] is that this method will not save a newly created instance where link:../ref/Domain%20Classes/findOrSaveBy.html[findOrSaveBy] does.
+Dynamic method that uses the properties of the domain class to create query method expressions that return the first result of the query. This method behaves like link:../Domain%20Classes/findBy.html[findBy] except that it will never return `null`.  If a matching instance cannot be found then a new instance will be created and returned, populated with values represented in the query parameters. The difference between this method and link:../Domain%20Classes/findOrSaveBy.html[findOrSaveBy] is that this method will not save a newly created instance where link:../Domain%20Classes/findOrSaveBy.html[findOrSaveBy] does.
 
 
 === Examples

--- a/src/en/ref/Domain Classes/findOrCreateWhere.adoc
+++ b/src/en/ref/Domain Classes/findOrCreateWhere.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-Uses named arguments that match the property names of the domain class to produce a query that returns the first result.  This method behaves just like link:../ref/Domain%20Classes/findWhere.html[findWhere] except that it will never return `null`.  If a matching instance cannot be found then a new instance will be created, populated with values from the query parameters and returned.  The difference between this method and link:../ref/Domain%20Classes/findOrSaveWhere.html[findOrSaveWhere] is that this method will not save a newly created instance where link:../ref/Domain%20Classes/findOrSaveWhere.html[findOrSaveWhere] does.
+Uses named arguments that match the property names of the domain class to produce a query that returns the first result.  This method behaves just like link:../Domain%20Classes/findWhere.html[findWhere] except that it will never return `null`.  If a matching instance cannot be found then a new instance will be created, populated with values from the query parameters and returned.  The difference between this method and link:../Domain%20Classes/findOrSaveWhere.html[findOrSaveWhere] is that this method will not save a newly created instance where link:../Domain%20Classes/findOrSaveWhere.html[findOrSaveWhere] does.
 
 
 === Examples

--- a/src/en/ref/Domain Classes/findOrSaveBy.adoc
+++ b/src/en/ref/Domain Classes/findOrSaveBy.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-Dynamic method that uses the properties of the domain class to create query method expressions that return the first result of the query. This method behaves like link:../ref/Domain%20Classes/findBy.html[findBy] except that it will never return `null`.  If a matching instance cannot be found then a new instance will be created, populated with values represented in the query parameters, saved and returned. The difference between this method and link:../ref/Domain%20Classes/findOrCreateBy.html[findOrCreateBy] is that this method will save any newly created instance where link:../ref/Domain%20Classes/findOrCreateBy.html[findOrCreateBy] does not.
+Dynamic method that uses the properties of the domain class to create query method expressions that return the first result of the query. This method behaves like link:../Domain%20Classes/findBy.html[findBy] except that it will never return `null`.  If a matching instance cannot be found then a new instance will be created, populated with values represented in the query parameters, saved and returned. The difference between this method and link:../Domain%20Classes/findOrCreateBy.html[findOrCreateBy] is that this method will save any newly created instance where link:../Domain%20Classes/findOrCreateBy.html[findOrCreateBy] does not.
 
 
 === Examples

--- a/src/en/ref/Domain Classes/findOrSaveWhere.adoc
+++ b/src/en/ref/Domain Classes/findOrSaveWhere.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-Uses named arguments corresponding to property names of the domain class to execute a query returning the first matching result. This method behaves just like link:../ref/Domain%20Classes/findWhere.html[findWhere] except that it will never return `null`. If a matching instance cannot be found in the database then a new instance is created, populated with values from the query parameters, saved and returned.  The difference between this method and link:../ref/Domain%20Classes/findOrCreateWhere.html[findOrCreateWhere] is that this method will save a newly created instance where link:../ref/Domain%20Classes/findOrCreateWhere.html[findOrCreateWhere] does not.
+Uses named arguments corresponding to property names of the domain class to execute a query returning the first matching result. This method behaves just like link:../Domain%20Classes/findWhere.html[findWhere] except that it will never return `null`. If a matching instance cannot be found in the database then a new instance is created, populated with values from the query parameters, saved and returned.  The difference between this method and link:../Domain%20Classes/findOrCreateWhere.html[findOrCreateWhere] is that this method will save a newly created instance where link:../Domain%20Classes/findOrCreateWhere.html[findOrCreateWhere] does not.
 
 
 === Examples

--- a/src/en/ref/Domain Classes/first.adoc
+++ b/src/en/ref/Domain Classes/first.adoc
@@ -41,7 +41,7 @@ Parameters:
 
 See also:
 
-* link:../ref/Domain%20Classes/last.html[last]
+* link:last.html[last]
 
 NOTE: Note that the first() and last() methods are not supported on domain classes which use a composite primary key.
 

--- a/src/en/ref/Domain Classes/hasErrors.adoc
+++ b/src/en/ref/Domain Classes/hasErrors.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-Check if a domain class instance has validation errors following a call to link:../ref/Domain%20Classes/validate.html[validate] or link:../ref/Domain%20Classes/save.html[save], or following link:theWebLayer.html#dataBinding[data binding]
+Check if a domain class instance has validation errors following a call to link:validate.html[validate] or link:.save.html[save], or following link:{guidePath}/theWebLayer.html#dataBinding[data binding]
 
 
 === Examples

--- a/src/en/ref/Domain Classes/isAttached.adoc
+++ b/src/en/ref/Domain Classes/isAttached.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-Returns whether the domain instance is attached to a currently active Hibernate session. This method is often used on conjunction with the link:../ref/Domain%20Classes/merge.html[merge] or link:../ref/Domain%20Classes/attach.html[attach] methods.
+Returns whether the domain instance is attached to a currently active Hibernate session. This method is often used on conjunction with the link:merge.html[merge] or link:attach.html[attach] methods.
 
 
 === Examples
@@ -25,4 +25,4 @@ if (!b.isAttached()) {
 === Description
 
 
-Persistent instances are associated with a persistence Session. A new Session is created for each request and is closed at the end of the request. If an object is read from the session and placed into a web scope such as the HttpSession it is seen as detached, since the persistence session has been closed. You can use the link:../ref/Domain%20Classes/attach.html[attach] method to re-attach an existing persistent instance to the persistence session of the current request.
+Persistent instances are associated with a persistence Session. A new Session is created for each request and is closed at the end of the request. If an object is read from the session and placed into a web scope such as the HttpSession it is seen as detached, since the persistence session has been closed. You can use the link:attach.html[attach] method to re-attach an existing persistent instance to the persistence session of the current request.

--- a/src/en/ref/Domain Classes/last.adoc
+++ b/src/en/ref/Domain Classes/last.adoc
@@ -41,7 +41,7 @@ Parameters:
 
 See also:
 
-* link:../ref/Domain%20Classes/first.html[first]
+* link:first.html[first]
 
 NOTE: Note that the first() and last() methods are not supported on domain classes which use a composite primary key.
 

--- a/src/en/ref/Domain Classes/mapping.adoc
+++ b/src/en/ref/Domain Classes/mapping.adoc
@@ -28,8 +28,5 @@ class Person {
 }
 ----
 
-<<<<<<< HEAD
+
 This example uses the http://gorm.grails.org/snapshot/hibernate/6.0.x/index.html#ormdsl[ORM DSL] to map the `Person` class onto a table called `people`
-=======
-This example uses the link:GORM.html#ormdsl[ORM DSL] to map the `Person` class onto a table called `people`
->>>>>>> 3.1.x

--- a/src/en/ref/Domain Classes/merge.adoc
+++ b/src/en/ref/Domain Classes/merge.adoc
@@ -22,7 +22,7 @@ b = b.merge()
 === Description
 
 
-The `merge` method is similar in function to the link:../ref/Domain%20Classes/save.html[save] method, but not in behaviour. `merge` allows the merging of "detached" instances such as those stored in the HTTP link:../ref/Controllers/session.html[session]. Each persistent instance is associated with a persistence context. A new persistence context is created for each link:../ref/Controllers/request.html[request]. The result is that objects stored in the HTTP session lose their persistence context on subsequent requests. In this case you can't simply call link:../ref/Domain%20Classes/save.html[save] as the domain class is not associated with a current context.
+The `merge` method is similar in function to the link:save.html[save] method, but not in behaviour. `merge` allows the merging of "detached" instances such as those stored in the HTTP link:../Controllers/session.html[session]. Each persistent instance is associated with a persistence context. A new persistence context is created for each link:../Controllers/request.html[request]. The result is that objects stored in the HTTP session lose their persistence context on subsequent requests. In this case you can't simply call link:save.html[save] as the domain class is not associated with a current context.
 
 The `merge` method on the other hand lets you merge a detached object's state back into the current Hibernate session. Unlike the `save` method this method returns a new instance of the class representing the re-attached object. In other words you *must* write code like this:
 

--- a/src/en/ref/Domain Classes/namedQueries.adoc
+++ b/src/en/ref/Domain Classes/namedQueries.adoc
@@ -83,7 +83,7 @@ def pubs = Publication.oldPublicationsLargerThan(350).findAllByTitleLike('%Grail
 def pubs = Publication.recentPublicationsWithBookInTitle().list()
 ----
 
-The `list` method on named queries supports the same attributes as the static `list` method added to domain classes (sort, order, ignoreCase, fetch etc...).  See the link:../ref/Domain%20Classes/list.html[list] docs for details.
+The `list` method on named queries supports the same attributes as the static `list` method added to domain classes (sort, order, ignoreCase, fetch etc...).  See the link:list.html[list] docs for details.
 
 NOTE: Note that calling something like `Publication.recentPublications.get(42)` is not the same as calling something like `Publication.get(42)`.  The former will only return a `Publication` if the `Publication` with id 42 meets all the criteria defined in the `recentPublications` named query.
 

--- a/src/en/ref/Domain Classes/properties.adoc
+++ b/src/en/ref/Domain Classes/properties.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-Allows access to the domain class properties as a Map and is typically used for link:theWebLayer.html#dataBinding[data binding] to perform type conversions allowing properties to be set from request parameters or other Maps.
+Allows access to the domain class properties as a Map and is typically used for link:{guidePath}/theWebLayer.html#dataBinding[data binding] to perform type conversions allowing properties to be set from request parameters or other Maps.
 
 
 === Examples

--- a/src/en/ref/Domain Classes/read.adoc
+++ b/src/en/ref/Domain Classes/read.adoc
@@ -21,7 +21,7 @@ def b = Book.read(1)
 === Description
 
 
-The `read` method is similar to the link:../ref/Domain%20Classes/get.html[get] method except that automatic dirty detection is disabled. The instance isn't truly read-only - you can modify it - but if it isn't explicitly saved but has been modified, it won't be updated in the database during a flush. But you can explicitly call `save()` and it will be updated. There is one exception to this though - any associated collections, for example an `Author`'s `books` collection, will participate in automatic flushing and dirty detection. This is because mapped collections are treated differently than regular properties and they manage their own dirty checking indepenent of the containing domain class.
+The `read` method is similar to the link:get.html[get] method except that automatic dirty detection is disabled. The instance isn't truly read-only - you can modify it - but if it isn't explicitly saved but has been modified, it won't be updated in the database during a flush. But you can explicitly call `save()` and it will be updated. There is one exception to this though - any associated collections, for example an `Author`'s `books` collection, will participate in automatic flushing and dirty detection. This is because mapped collections are treated differently than regular properties and they manage their own dirty checking indepenent of the containing domain class.
 
 Parameters:
 

--- a/src/en/ref/Domain Classes/removeFrom.adoc
+++ b/src/en/ref/Domain Classes/removeFrom.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-Opposite of the <<ref-domain-classes-addTo,addTo>> method in that it removes instances from an association.
+Opposite of the link:addTo.html[addTo] method in that it removes instances from an association.
 
 
 === Examples

--- a/src/en/ref/Domain Classes/save.adoc
+++ b/src/en/ref/Domain Classes/save.adoc
@@ -29,7 +29,7 @@ The `save` method informs the persistence context that an instance should be sav
 b.save(flush: true)
 ----
 
-The `save` method returns `null` if link:validation.html[validation] failed and the instance was not persisted, or the instance itself if successful. This lets you use "Groovy truth" (`null` is considered `false`) to write code like the following:
+The `save` method returns `null` if link:{guidePath}/validation.html[validation] failed and the instance was not persisted, or the instance itself if successful. This lets you use "Groovy truth" (`null` is considered `false`) to write code like the following:
 
 [source,java]
 ----
@@ -45,7 +45,7 @@ Parameters:
 * `validate` (optional) - Set to `false` if validation should be skipped
 * `flush` (optional) - When set to `true` flushes the persistence context, persisting the object immediately and updating the `version` column for http://gorm.grails.org/6.0.x/hibernate/manual/index.html#locking[optimistic locking]
 * `insert` (optional) - When set to `true` will force Hibernate to do a SQL INSERT; this is useful in certain situations (for example when using assigned ids) and Hibernate cannot detect whether to do an INSERT or an UPDATE
-* `failOnError` (optional) - When set to `true` the `save` method with throw a `grails.validation.ValidationException` if link:validation.html[validation] fails. This behavior may also be triggered by setting the `grails.gorm.failOnError` property in `grails-app/conf/application.groovy`. If the Config property is set and the argument is passed to the method, the method argument will always take precedence.  For more details about the config property and other GORM config options, see the <<configGORM,GORM Configuration Options>> section of The User Guide.
+* `failOnError` (optional) - When set to `true` the `save` method with throw a `grails.validation.ValidationException` if link:{guidePath}/validation.html[validation] fails. This behavior may also be triggered by setting the `grails.gorm.failOnError` property in `grails-app/conf/application.groovy`. If the Config property is set and the argument is passed to the method, the method argument will always take precedence.  For more details about the config property and other GORM config options, see the link:{guidePath}/conf.html#configGORM[GORM Configuration Options] section of The User Guide.
 * `deepValidate` (optional) - Determines whether associations of the domain instance should also be validated, i.e. whether validation cascades. This is `true` by default - set to `false` to disable cascading validation.
 
 NOTE: By default GORM classes are configured for http://gorm.grails.org/6.0.x/hibernate/manual/index.html#locking[optimistic locking], which is a feature of Hibernate that involves storing an incrementing version in the table. This value is only updated in the database when the Hibernate session is flushed.

--- a/src/en/ref/Domain Classes/validate.adoc
+++ b/src/en/ref/Domain Classes/validate.adoc
@@ -6,13 +6,13 @@
 === Purpose
 
 
-Validates a domain class against the applied constraints (see link:validation.html[validation])
+Validates a domain class against the applied constraints (see link:{guidePath}/validation.html[validation])
 
 
 === Description
 
 
-The `validate` method validates a domain class based on its defined link:validation.html#constraints[Constraints]. The errors are stored in the link:../ref/Domain%20Classes/errors.html[errors] property of the domain class instance.
+The `validate` method validates a domain class based on its defined link:{guidePath}/validation.html#constraints[Constraints]. The errors are stored in the link:errors.html[errors] property of the domain class instance.
 
 The `validate` method accepts an optional `List` argument which contains the names of the properties to be validated. When a `List` of names is specified, only those properties will be validated.
 

--- a/src/en/ref/Domain Classes/withCriteria.adoc
+++ b/src/en/ref/Domain Classes/withCriteria.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-Allows inline execution of Criteria queries. See the link:../ref/Domain%20Classes/createCriteria.html[createCriteria] method for reference.
+Allows inline execution of Criteria queries. See the link:createCriteria.html[createCriteria] method for reference.
 
 
 === Return value

--- a/src/en/ref/Plug-ins.adoc
+++ b/src/en/ref/Plug-ins.adoc
@@ -2,14 +2,14 @@
 === plugin Usage
 
 
-A plugin provides additional capability to the Grails runtime and is created with the link:../ref/Command%20Line/create-plugin.html[create-plugin] command:
+A plugin provides additional capability to the Grails runtime and is created with the link:../Command%20Line/create-plugin.html[create-plugin] command:
 
 [source,java]
 ----
 grails create-plugin simple
 ----
 
-This will create a plugin project which can then be packaged with <<ref-command-line-package-plugin,package-plugin>>:
+This will create a plugin project which can then be packaged with link:../Command%20Line/package-plugin.html[package-plugin]:
 
 [source,java]
 ----
@@ -23,4 +23,4 @@ To install the plugin to your local Maven repository you can use the `install` c
 grails install
 ----
 
-Refer to the user guide topic on link:plugins.html[plugins] for more information.
+Refer to the user guide topic on link:{guidePath}/plugins.html[plugins] for more information.

--- a/src/en/ref/Plug-ins/URL mappings.adoc
+++ b/src/en/ref/Plug-ins/URL mappings.adoc
@@ -34,8 +34,7 @@ class UrlMappings {
 
 === Description
 
-
-Refer to the section on <<urlmappings,URL Mapping>> in the Grails user guide which details Grails' URL mappings.
+Refer to the section on link:{guidePath}/theWebLayer.html#urlmappings[URL Mappings] in the Grails user guide which details Grails' URL mappings.
 
 Configured Spring Beans:
 

--- a/src/en/ref/Plug-ins/codecs.adoc
+++ b/src/en/ref/Plug-ins/codecs.adoc
@@ -30,7 +30,7 @@ assert "<p>Hello World!</p>" == "&lt;p&gt;Hello World!&lt;/p&gt;".decodeHTML()
 === Description
 
 
-This plugin searches for classes with names that end in the convention `Codec` and dynamically registers `encodeAs<<Codec>>` and `decode<<Codec>>` methods on `java.lang.Object` so that any data can be encoded and decoded. For more information refer to the section of <<codecs,Encoding and Decoding Objects>> in the user guide.
+This plugin searches for classes with names that end in the convention `Codec` and dynamically registers `encodeAs<<Codec>>` and `decode<<Codec>>` methods on `java.lang.Object` so that any data can be encoded and decoded. For more information refer to the section of link:{guidePath}/security.html#codecs[Encoding and Decoding Objects] in the user guide.
 
 Provided Codecs:
 

--- a/src/en/ref/Plug-ins/dataSource.adoc
+++ b/src/en/ref/Plug-ins/dataSource.adoc
@@ -39,7 +39,7 @@ dataSource {
 === Description
 
 
-Refer to the section on <<dataSource,Data Sources>> in the Grails user guide.
+Refer to the section on link:{guidePath}/conf.html#dataSource[Data Sources] in the Grails user guide.
 
 Configured Spring Beans:
 

--- a/src/en/ref/Plug-ins/domainClasses.adoc
+++ b/src/en/ref/Plug-ins/domainClasses.adoc
@@ -27,7 +27,7 @@ class Book {
 === Description
 
 
-Refer to the section on link:GORM.html[GORM] in the Grails user guide which details how to create Grails domain classes.
+Refer to the section on link:http://gorm.grails.org/6.0.x/hibernate/manual/[GORM] in the Grails user guide which details how to create Grails domain classes.
 
 Configured Spring Beans given a domain class of `Book`:
 

--- a/src/en/ref/Plug-ins/i18n.adoc
+++ b/src/en/ref/Plug-ins/i18n.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-The `i18n` plugin configures Grails' support for <<i18n,Internationalization>>.
+The `i18n` plugin configures Grails' support for link:{guidePath}/i18n.html[Internationalization].
 
 
 === Examples
@@ -27,7 +27,7 @@ default.not.found.message={0} not found with id {1}
 === Description
 
 
-Refer to the section on <<i18n,Internationalization>> in the Grails user guide which details Grails' i18n support.
+Refer to the section on link:{guidePath}/i18n.html[Internationalization] in the Grails user guide which details Grails' i18n support.
 
 Configured Spring Beans:
 

--- a/src/en/ref/Plug-ins/logging.adoc
+++ b/src/en/ref/Plug-ins/logging.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-The `logging` plugin configures Grails' support for <<logging,Logging>> with logback.
+The `logging` plugin configures Grails' support for link:{guidePath}/conf.html#logging[Logging] with logback.
 
 
 === Examples
@@ -30,4 +30,4 @@ catch (Exception e) {
 === Description
 
 
-Refer to the section on <<logging,Logging>> in the Grails user guide which details Grails' logging support.
+Refer to the section on link:{guidePath}/conf.html#logging[Logging] in the Grails user guide which details Grails' logging support.

--- a/src/en/ref/Plug-ins/scaffolding.adoc
+++ b/src/en/ref/Plug-ins/scaffolding.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-The `scaffolding` plugin configures Grails' support for CRUD via link:scaffolding.html[scaffolding].
+The `scaffolding` plugin configures Grails' support for CRUD via link:{guidePath}/scaffolding.html[scaffolding].
 
 
 === Examples
@@ -29,4 +29,4 @@ class BookController {
 === Description
 
 
-Refer to the section on link:scaffolding.html[scaffolding] in the Grails user guide which details Grails' scaffolding support.
+Refer to the section on link:{guidePath}/scaffolding.html[scaffolding] in the Grails user guide which details Grails' scaffolding support.

--- a/src/en/ref/Plug-ins/services.adoc
+++ b/src/en/ref/Plug-ins/services.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-The `services` plugin configures Grails' support for <<services,Services>>.
+The `services` plugin configures Grails' support for link:{guidePath}/services.html[Services].
 
 
 === Examples
@@ -27,7 +27,7 @@ class BookService {
 === Description
 
 
-Refer to the section on <<services,Services>> in the Grails user guide which details Grails' services.
+Refer to the section on link:{guidePath}/services.html[Services] in the Grails user guide which details Grails' services.
 
 Configured Spring Beans given a service class of `BookService`:
 

--- a/src/en/ref/Plug-ins/servlets.adoc
+++ b/src/en/ref/Plug-ins/servlets.adoc
@@ -12,7 +12,7 @@ The `servlets` plugin enhances Servlet API classes with new methods
 === Examples
 
 
-Allows attributes from the link:../ref/Controllers/request.html[request], link:../ref/Controllers/session.html[session], and link:../ref/Controllers/servletContext.html[servletContext] to be be accessed with the de-reference operator:
+Allows attributes from the link:../Controllers/request.html[request], link:../Controllers/session.html[session], and link:../Controllers/servletContext.html[servletContext] to be be accessed with the de-reference operator:
 
 [source,java]
 ----

--- a/src/en/ref/Services.adoc
+++ b/src/en/ref/Services.adoc
@@ -2,7 +2,7 @@
 === Service Usage
 
 
-A service contains business logic that can be reused across a Grails application. In Grails a service is a class with a name that ends in the convention "Service" and lives in the `grails-app/services` directory. A service can be created with the link:../ref/Command%20Line/create-service.html[create-service] command:
+A service contains business logic that can be reused across a Grails application. In Grails a service is a class with a name that ends in the convention "Service" and lives in the `grails-app/services` directory. A service can be created with the link:../Command%20Line/create-service.html[create-service] command:
 
 [source,java]
 ----
@@ -22,4 +22,4 @@ class BookService {
 }
 ----
 
-Refer to the user guide topic on <<services,Services>> for more information.
+Refer to the user guide topic on link:{guidePath}/services.html[Services] for more information.

--- a/src/en/ref/Servlet API/request.adoc
+++ b/src/en/ref/Servlet API/request.adoc
@@ -40,8 +40,8 @@ Grails enhances the `HttpServletRequest` instance by adding the following new pr
 * `each` - Implementation of Groovy's `each` method for iterating over request attributes.
 * `find` - Implementation of Groovy's default `find` method for searching request attributes.
 * `findAll` - Implementation of Groovy's default `findAll` method for searching request attributes.
-* `format` - The request format, used for link:theWebLayer.html#contentNegotiation[Content Negotiation].
-* `withFormat(Closure)` - The withFormat method, used for link:theWebLayer.html#contentNegotiation[Content Negotiation].
+* `format` - The request format, used for link:{guidePath}/theWebLayer.html#contentNegotiation[Content Negotiation].
+* `withFormat(Closure)` - The withFormat method, used for link:{guidePath}/theWebLayer.html#contentNegotiation[Content Negotiation].
 * `xhr` - Returns `true` if the current request is an Ajax request.
 
 The `XML` and `JSON` properties are useful for XML APIs and can be used to parse incoming XML or JSON packages. For example given a request body of:

--- a/src/en/ref/Servlet API/response.adoc
+++ b/src/en/ref/Servlet API/response.adoc
@@ -28,8 +28,8 @@ class BookController {
 
 The Servlet API's `HttpServletResponse` class can be used within Grails to perform all typical activities such as writing out binary data, writing directly to the response and sending error response codes to name but a few. Refer to the documentation on the http://docs.oracle.com/javaee/1.4/api/javax/servlet/http/HttpServletResponse.html[HttpServletResponse] class in the Servlet API for more information. Grails provides the following additional methods and/or properties on the `response` object
 
-* `format` - The request format, used for link:theWebLayer.html#contentNegotiation[Content Negotiation].
-* `withFormat(Closure)` - The withFormat method, used for link:theWebLayer.html#contentNegotiation[Content Negotiation].
+* `format` - The request format, used for link:{guidePath}/theWebLayer.html#contentNegotiation[Content Negotiation].
+* `withFormat(Closure)` - The withFormat method, used for link:{guidePath}/theWebLayer.html#contentNegotiation[Content Negotiation].
 
 Grails also overrides the left shift operator on the `response` object making it easier to write to the response writer:
 

--- a/src/en/ref/Tag Libraries.adoc
+++ b/src/en/ref/Tag Libraries.adoc
@@ -2,7 +2,7 @@
 === Tag Library Usage
 
 
-A tag library fulfills role of "view helper" in the Model View Controller (MVC) pattern and helps with GSP rendering. In Grails a tag library is a class with a name that ends in the convention "TagLib" and lives in the `grails-app/taglib` directory. Use the link:../ref/Command%20Line/create-taglib.html[create-taglib] command to create a tag library:
+A tag library fulfills role of "view helper" in the Model View Controller (MVC) pattern and helps with GSP rendering. In Grails a tag library is a class with a name that ends in the convention "TagLib" and lives in the `grails-app/taglib` directory. Use the link:../Command%20Line/create-taglib.html[create-taglib] command to create a tag library:
 
 [source,java]
 ----
@@ -24,4 +24,4 @@ class FormatTagLib {
 
 Each Closure property in a tag library that takes one or two arguments is considered a tag. The first argument (typically named `attrs`) will contain the attributes of the tag whilst the optional second argument (typically named `body`) is Closure that represents the inner HTML of the tag declaration from the GSP.
 
-Refer to the user guide topic on <<taglibs,Tag Libraries>> for more information.
+Refer to the user guide topic on link:{guidePath}/theWebLayer.html#taglibs[Tag Libraries] for more information.

--- a/src/en/ref/Tag Libraries/pageScope.adoc
+++ b/src/en/ref/Tag Libraries/pageScope.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-A reference to the binding of the GSP that the tag library is being executed within. Allows access to variables set with the link:../ref/Tags/set.html[set] tag and those passed to the page from the controller model.
+A reference to the binding of the GSP that the tag library is being executed within. Allows access to variables set with the link:../Tags/set.html[set] tag and those passed to the page from the controller model.
 
 
 === Examples

--- a/src/en/ref/Tag Libraries/params.adoc
+++ b/src/en/ref/Tag Libraries/params.adoc
@@ -22,7 +22,7 @@ class BookController {
 }
 ----
 
-To perform data binding (see link:theWebLayer.html#dataBinding[data binding] in the user guide):
+To perform data binding (see link:{guidePath}theWebLayer.html#dataBinding[data binding] in the user guide):
 
 [source,groovy]
 ----
@@ -35,7 +35,7 @@ def save() {
 === Description
 
 
-The standard Servlet API provides access to parameters with the `HttpServletRequest` object. Although Grails provides the same capability through the link:../ref/Controllers/request.html[request] object, it goes a bit further by providing a mutable map of request parameters called `params`.
+The standard Servlet API provides access to parameters with the `HttpServletRequest` object. Although Grails provides the same capability through the link:../Controllers/request.html[request] object, it goes a bit further by providing a mutable map of request parameters called `params`.
 
 The `params` object can be indexed into using the array index operator or de-reference operator, so given so given the URL `/hello?foo=bar` you can access `foo` with
 
@@ -43,7 +43,7 @@ The `params` object can be indexed into using the array index operator or de-ref
 println params.foo
 ----
 
-The params object can also be used to bind request parameters onto the properties of a domain class using either the constructor or the link:../ref/Domain%20Classes/properties.html[properties] property:
+The params object can also be used to bind request parameters onto the properties of a domain class using either the constructor or the link:../Domain%20Classes/properties.html[properties] property:
 
 [source,groovy]
 ----
@@ -52,4 +52,4 @@ book = Book.get(1)
 book.properties = params
 ----
 
-For further reading see link:theWebLayer.html#dataBinding[data binding] in the user guide.
+For further reading see link:{guidePath}theWebLayer.html#dataBinding[data binding] in the user guide.

--- a/src/en/ref/Tag Libraries/request.adoc
+++ b/src/en/ref/Tag Libraries/request.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-The <<ref-servlet-api-request,request>> object is an instance of the Servlet API's http://docs.oracle.com/javaee/1.4/api/javax/servlet/http/HttpServletRequest.html[HttpServletRequest] class
+The link:../Servlet%20API/request.html[request] object is an instance of the Servlet API's http://docs.oracle.com/javaee/1.4/api/javax/servlet/http/HttpServletRequest.html[HttpServletRequest] class
 
 
 === Examples
@@ -29,4 +29,4 @@ class BookController {
 
 The http://docs.oracle.com/javaee/1.4/api/javax/servlet/http/HttpServletRequest.html[HttpServletRequest] class is useful for, amongst other things, obtaining request headers, storing request scoped attributes and establishing information about the client. Refer to the Servlet API's javadocs for further information.
 
-NOTE: The additional methods added to the <<ref-servlet-api-request,request>> object are documented in the Grails Servlet API reference guide
+NOTE: The additional methods added to the link:../Servlet%20API/request.html[request] object are documented in the Grails Servlet API reference guide

--- a/src/en/ref/Tag Libraries/response.adoc
+++ b/src/en/ref/Tag Libraries/response.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-The <<ref-servlet-api-response,response>> object is an instance of the Servlet API's http://docs.oracle.com/javaee/1.4/api/javax/servlet/http/HttpServletResponse.html[HttpServletResponse] class
+The link:../Servlet%20API/response.html[response] object is an instance of the Servlet API's http://docs.oracle.com/javaee/1.4/api/javax/servlet/http/HttpServletResponse.html[HttpServletResponse] class
 
 
 === Examples
@@ -28,4 +28,4 @@ class BookController {
 
 The Servlet API's `HttpServletResponse` class can be used within Grails to perform all typical activities such as writing out binary data, writing directly to the response and sending error response codes to name but a few. Refer to the documentation on the http://docs.oracle.com/javaee/1.4/api/javax/servlet/http/HttpServletResponse.html[HttpServletResponse] class in the Servlet API for more information.
 
-NOTE: The additional methods added to the <<ref-servlet-api-response,response>> object are documented in the Grails Servlet API reference guide
+NOTE: The additional methods added to the link:../Servlet%20API/response.html[response] object are documented in the Grails Servlet API reference guide

--- a/src/en/ref/Tag Libraries/servletContext.adoc
+++ b/src/en/ref/Tag Libraries/servletContext.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-The <<ref-servlet-api-servletContext,servletContext>> object is an instance of the Servlet API's http://docs.oracle.com/javaee/1.4/api/javax/servlet/ServletContext.html[ServletContext] class.
+The link:../Servlet%20API/servletContext.html[servletContext] object is an instance of the Servlet API's http://docs.oracle.com/javaee/1.4/api/javax/servlet/ServletContext.html[ServletContext] class.
 
 
 === Examples
@@ -35,4 +35,4 @@ class BookController {
 
 The Servlet API's http://docs.oracle.com/javaee/1.4/api/javax/servlet/ServletContext.html[ServletContext] is useful for, amongst other things, storing global application attributes, reading local server resources and establishing information about the servlet container.
 
-NOTE: Grails adds additional methods to the standard Servlet API's <<ref-servlet-api-servletContext,servletContext>> object. See link for details.
+NOTE: Grails adds additional methods to the standard Servlet API's link:../Servlet%20API/servletContext.html[servletContext] object. See link for details.

--- a/src/en/ref/Tag Libraries/session.adoc
+++ b/src/en/ref/Tag Libraries/session.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-The <<ref-servlet-api-session,session>> object is an instance of the Servlet API's http://docs.oracle.com/javaee/1.4/api/javax/servlet/http/HttpSession.html[HttpSession] class
+The link:../Servlet%20API/session.html[session] object is an instance of the Servlet API's http://docs.oracle.com/javaee/1.4/api/javax/servlet/http/HttpSession.html[HttpSession] class
 
 
 === Examples
@@ -32,4 +32,4 @@ class UserController {
 
 The http://docs.oracle.com/javaee/1.4/api/javax/servlet/http/HttpSession.html[HttpSession] class is useful for associated session data with a client.
 
-NOTE: The additional methods added to the <<ref-servlet-api-session,session>> object are documented in the Grails Servlet API reference guide
+NOTE: The additional methods added to the link:../Servlet%20API/session.html[session] object are documented in the Grails Servlet API reference guide

--- a/src/en/ref/Tags/applyLayout.adoc
+++ b/src/en/ref/Tags/applyLayout.adoc
@@ -44,7 +44,7 @@ Attributes
 * `url` - (optional) The URL to retrieve the content from and apply a layout to
 * `contentType` (optional) - The content type to use, default is "text/html"
 * `encoding` (optional) - The encoding to use
-* `params` (optional) - The params to pass onto the page object (retrievable with the link:../ref/Tags/pageProperty.html[pageProperty] tag)
+* `params` (optional) - The params to pass onto the page object (retrievable with the link:../Tags/pageProperty.html[pageProperty] tag)
 * `model` (optional) - The model (as java.util.Map) to pass to the view and layout templates
 
 

--- a/src/en/ref/Tags/country.adoc
+++ b/src/en/ref/Tags/country.adoc
@@ -22,7 +22,7 @@ Supported countries: <g:country code="gbr"/>, <g:country code="deu"/>
 === Description
 
 
-Uses the internal ISO3166_3 country code date that the link:../ref/Tags/countrySelect.html[countrySelect] tag is based upon, to quickly render the name of a country given the code.
+Uses the internal ISO3166_3 country code date that the link:countrySelect.html[countrySelect] tag is based upon, to quickly render the name of a country given the code.
 
 For internationalized versions of the country names, define these in your message bundles and use the `<g:message>` tag instead.
 

--- a/src/en/ref/Tags/createLinkTo.adoc
+++ b/src/en/ref/Tags/createLinkTo.adoc
@@ -2,7 +2,7 @@
 == createLinkTo
 
 
-WARNING: Deprecated: Use link:../ref/Tags/resource.html[resource] instead.
+WARNING: Deprecated: Use link:../Tags/resource.html[resource] instead.
 
 
 === Purpose

--- a/src/en/ref/Tags/fieldValue.adoc
+++ b/src/en/ref/Tags/fieldValue.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-Inspects a bean which has been the subject of link:theWebLayer.html#dataBinding[data binding] and obtains the value of the field. If the bean had `errors` during data binding then the originally submitted value is returned from the bean's `errors` object else the value from the bean's property is returned. The value returned will be HTML-encoded.
+Inspects a bean which has been the subject of link:{guidePath}/theWebLayer.html#dataBinding[data binding] and obtains the value of the field. If the bean had `errors` during data binding then the originally submitted value is returned from the bean's `errors` object else the value from the bean's property is returned. The value returned will be HTML-encoded.
 
 
 === Examples

--- a/src/en/ref/Tags/hasErrors.adoc
+++ b/src/en/ref/Tags/hasErrors.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-Checks whether a bean, request scope, or model reference has any errors and if so invokes the body of the tag. Typically used in conjunction with either link:../ref/Tags/eachError.html[eachError] or link:../ref/Tags/renderErrors.html[renderErrors]
+Checks whether a bean, request scope, or model reference has any errors and if so invokes the body of the tag. Typically used in conjunction with either link:../Tags/eachError.html[eachError] or link:../Tags/renderErrors.html[renderErrors]
 
 
 === Examples

--- a/src/en/ref/Tags/message.adoc
+++ b/src/en/ref/Tags/message.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-Resolves a message from the given code or error. Normally used in conjunction with link:../ref/Tags/eachError.html[eachError]
+Resolves a message from the given code or error. Normally used in conjunction with link:../Tags/eachError.html[eachError]
 
 
 === Examples

--- a/src/en/ref/Tags/render.adoc
+++ b/src/en/ref/Tags/render.adoc
@@ -94,7 +94,7 @@ Attributes
 * `var` (optional) - The variable name of the bean to be referenced in the template
 * `plugin` (optional) - The plugin to look for the template in
 
-See link:../ref/Controllers/render.html[render] in the user guide for more information.
+See link:../Controllers/render.html[render] in the user guide for more information.
 
 
 === Source

--- a/src/en/ref/Tags/unless.adoc
+++ b/src/en/ref/Tags/unless.adoc
@@ -6,7 +6,7 @@
 === Purpose
 
 
-Renders its body conditionally, based on an expression and/or current environment. The tag renders its body unless all of the specified conditions (test and/or environment) are `true`. Does the opposite of what the link:../ref/Tags/if.html[if] tag does.
+Renders its body conditionally, based on an expression and/or current environment. The tag renders its body unless all of the specified conditions (test and/or environment) are `true`. Does the opposite of what the link:../Tags/if.html[if] tag does.
 
 
 === Examples

--- a/src/en/ref/Tags/uploadForm.adoc
+++ b/src/en/ref/Tags/uploadForm.adoc
@@ -23,7 +23,7 @@ Creates a form that can submit multi-part data for file uploads.
 === Description
 
 
-Identical to the standard link:../ref/Tags/form.html[form] tag except that it sets the `enctype` attribute to `"multipart/form-data"` automatically.
+Identical to the standard link:../Tags/form.html[form] tag except that it sets the `enctype` attribute to `"multipart/form-data"` automatically.
 
 Attributes
 


### PR DESCRIPTION
Fixes broken links between Quick Reference and the Guide.

Example:  http://docs.grails.org/latest/ref/Plug-ins/URL%20mappings.html in

> Refer to the section on URL Mapping in the Grails user guide which details Grails' URL mappings.

If you click "URL Mapping” it doesn’t take you to http://docs.grails.org/latest/guide/theWebLayer.html#urlmappings anymore