### PR TITLE
meta properties in other files

### DIFF
--- a/src/en/ref/Tags/meta.adoc
+++ b/src/en/ref/Tags/meta.adoc
@@ -22,7 +22,7 @@ Built with Grails <g:meta name="info.app.grailsVersion"/>
 === Description
 
 
-Meta properties are populated from the `application.yml` file as well as the `grails.build.info` file if it exists, such as in a production environment, and include the application's version and the Grails version it requires. It can be used to expose some invariant data about your application at runtime. See the Application Metadata section for more details.
+Meta properties are populated from the `gradle.properties` (grailsVersion property) and the `build.gradle` (version property) file as well as the `grails.build.info` file if it exists, such as in a production environment, and include the application's version and the Grails version it requires. It can be used to expose some invariant data about your application at runtime. See the Application Metadata section for more details.
 
 Attributes
 


### PR DESCRIPTION
When I change the info.app.grailsVersion I do it in the gradle.properties file called grailsVersion and the info.app.version in the build.gradle file called version.  I do not see them in the application.yml file.