### PR TITLE
Turn accidental titles into list items

### DIFF
--- a/src/en/guide/testing/unitTesting/unitTestingDomains.adoc
+++ b/src/en/guide/testing/unitTesting/unitTestingDomains.adoc
@@ -172,9 +172,9 @@ mockDomain(Book, [
 
 There are 3 types of validateable classes:
 
-# Domain classes
-# Classes which implement the `Validateable` trait
-# Command Objects which have been made validateable automatically
+* Domain classes
+* Classes which implement the `Validateable` trait
+* Command Objects which have been made validateable automatically
 
 These are all easily testable in a unit test with no special configuration necessary as long as the test method is marked with `TestFor` or explicitly applies the `GrailsUnitTestMixin` using `TestMixin`.  See the examples below.
 


### PR DESCRIPTION
Some list items are using`#` instead of `*` and appear as titles