### PR TITLE
Info on adding HAL as an acceptable response format

### DIFF
--- a/src/en/guide/webServices/REST/hypermedia/hal.adoc
+++ b/src/en/guide/webServices/REST/hypermedia/hal.adoc
@@ -58,6 +58,31 @@ beans = {
 }
 ----
 
+You will also need to update the acceptable response formats for the resource so that the HAL format is included. Not doing so will result in a 406 - Not Acceptable response being returned from the server. 
+
+This can be done by setting the `formats` attribute of the `Resource` transformation:
+
+[source,groovy]
+----
+import grails.rest.*
+
+@Resource(uri='/books', formats=['json', 'xml', 'hal'])
+class Book {
+    ...
+}
+----
+
+Or by updating the `responseFormats` in the controller:
+
+[source,groovy]
+----
+class BookController extends RestfulController {
+    static responseFormats = ['json', 'xml', 'hal']
+
+    // ...
+}
+----
+
 With the bean in place requesting the HAL content type will return HAL:
 
 [source,groovy]


### PR DESCRIPTION
I followed the instructions on with rendering responses in the HAL format but kept on getting a 406 response from the server. I eventually figured out I needed to added HAL to the list of acceptable responses. This information was missing from the documentation so I created this proposed change.