### PR TITLE
The comma in the CSV format table

### DIFF
--- a/src/en/guide/upgrading.adoc
+++ b/src/en/guide/upgrading.adoc
@@ -27,22 +27,35 @@ Before and after interceptors were removed. So all `beforeInterceptor` and `afte
 
 The location of certain files have changed or been replaced with other files in Grails 3.0. The following table lists old default locations and their respective new locations:
 
-[format="csv", options="header"]
+[options="header"]
 |===
 
-*Old Location*,*New Location*,*Description*
-`grails-app/conf/BuildConfig.groovy`,`build.gradle`,Build time configuration is now defined in a Gradle build file
-`grails-app/conf/Config.groovy`,`grails-app/conf/application.groovy`,Renamed for consistency with Spring Boot
-`grails-app/conf/UrlMappings.groovy`,`grails-app/controllers/UrlMappings.groovy`,Moved since grails-app/conf is not a source directory anymore
-`grails-app/conf/BootStrap.groovy`,`grails-app/init/BootStrap.groovy`,Moved since grails-app/conf is not a source directory anymore
-`scripts`,`src/main/scripts`,Moved for consistency with Gradle
-`src/groovy`,`src/main/groovy`,Moved for consistency with Gradle
-`src/java`,`src/main/groovy` (yes, groovy!),Moved for consistency with Gradle
-`test/unit`,`src/test/groovy`,Moved for consistency with Gradle
-`test/integration`,`src/integration-test/groovy`,Moved for consistency with Gradle
-`web-app`,`src/main/webapp` or `src/main/resources/`,Moved for consistency with Gradle
-`\*GrailsPlugin.groovy`,`src/main/groovy`,The plugin descriptor moved to a source directory
+|*Old Location*|*New Location*|*Description*
+
+|`grails-app/conf/BuildConfig.groovy`|`build.gradle`|Build time configuration is now defined in a Gradle build file
+
+|`grails-app/conf/Config.groovy`|`grails-app/conf/application.groovy`|Renamed for consistency with Spring Boot
+
+|`grails-app/conf/UrlMappings.groovy`|`grails-app/controllers/UrlMappings.groovy`|Moved since grails-app/conf is not a source directory anymore
+
+|`grails-app/conf/BootStrap.groovy`|`grails-app/init/BootStrap.groovy`|Moved since grails-app/conf is not a source directory anymore
+
+|`scripts`|`src/main/scripts`|Moved for consistency with Gradle
+
+|`src/groovy`|`src/main/groovy`|Moved for consistency with Gradle
+
+|`src/java`|`src/main/groovy` (yes, groovy!)|Moved for consistency with Gradle
+
+|`test/unit`|`src/test/groovy`|Moved for consistency with Gradle
+
+|`test/integration`|`src/integration-test/groovy`|Moved for consistency with Gradle
+
+|`web-app`|`src/main/webapp` or `src/main/resources/`|Moved for consistency with Gradle
+
+|`\*GrailsPlugin.groovy`|`src/main/groovy`|The plugin descriptor moved to a source directory
+
 |===
+
 
 `src/main/resources/public` is recommended as `src/main/webapp` only gets included in WAR packaging but not in JAR packaging.
 


### PR DESCRIPTION
Since the table using csv format, the comma in "(yes, groovy!)" made the following table cells content messy.
Unable to get it escaped after an hour of searching and trying, I change it to traditional format table.