### PR TITLE
improving installation using SDKMAN docs

### DIFF
--- a/src/en/guide/gettingStarted/downloadingAndInstalling.adoc
+++ b/src/en/guide/gettingStarted/downloadingAndInstalling.adoc
@@ -1,9 +1,27 @@
+= Downloading and installing
+
 The first step to getting up and running with Grails is to install the distribution.
 
 The best way to install Grails on *nix systems is with http://sdkman.io[SDKMAN] which greatly simplifies installing and managing multiple Grails versions.
 
-For manual installation follow these steps:
+== Install with SDKMAN
 
+To install the latest version of Grails using SDKMAN, run this on your terminal:
+
+[source,shell]
+sdk install grails
+
+You can also specify a version
+
+[source,shell]
+sdk install grails 3.2.3
+
+You can find more information about SDKMAN usage on the http://sdkman.io/usage.html[SDKMAN Docs]
+
+== Manual installation
+
+For manual installation follow these steps:
+  
 * https://github.com/grails/grails-core/releases[Download] a binary distribution of Grails and extract the resulting zip file to a location of your choice
 * Set the GRAILS_HOME environment variable to the location where you extracted the zip
 ** On Unix/Linux based systems this is typically a matter of adding something like the following `export GRAILS_HOME=/path/to/grails` to your profile


### PR DESCRIPTION
The changes may sound obvious, but it helps those that never used SDKMAN and just wants to install Grails without going back and forth on SDKMAN docs.