### PR TITLE
Update findAllBy.adoc

### DIFF
--- a/src/en/ref/Domain Classes/findAllBy.adoc
+++ b/src/en/ref/Domain Classes/findAllBy.adoc
@@ -72,6 +72,8 @@ def results = Book.findAllByTitle("The Shining",
                  [max: 10, sort: "title", order: "desc", offset: 100])
 ----
 
+If no items meet the supplied criteria an empty list is returned.
+
 The following operator names can be used within the respective dynamic methods:
 
 * `LessThan`


### PR DESCRIPTION
Include a note indicating that if the find criteria are not met, the method returns an empty list (as opposed to null)