### PR TITLE
Update interceptorOrdering.adoc

### DIFF
--- a/src/en/guide/theWebLayer/interceptors/interceptorOrdering.adoc
+++ b/src/en/guide/theWebLayer/interceptors/interceptorOrdering.adoc
@@ -12,7 +12,7 @@ class AuthInterceptor {
 }
 ----
 
-The default value of the `order` property is 0.
+The default value of the `order` property is 0.  Interceptor execution order is determined by sorting the `order` property in an ascending direction and executing the lowest numerically ordered interceptor first. 
 
 The values `HIGHEST_PRECEDENCE` and `LOWEST_PRECEDENCE` can be used to define filters that should should run first or last respectively.
 


### PR DESCRIPTION
The documentation doesn't actually state the order in which interceptors are fired.  This patch adds clarification on the order in which interceptors are fired.