### PR TITLE
Disable publishing of /latest/ for 3.1.x documentation

### DIFF
--- a/travis-build.sh
+++ b/travis-build.sh
@@ -19,13 +19,16 @@ if [[ $TRAVIS_PULL_REQUEST == 'false' ]]; then
 
 		version="$TRAVIS_TAG"
 		version=${version:1}
-	    zipName="grails-docs-$version"
-	    export RELEASE_FILE="${zipName}.zip"
+		zipName="grails-docs-$version"
+		export RELEASE_FILE="${zipName}.zip"
 
-		git rm -rf latest/
-		mkdir -p latest
-		cp -r ../build/docs/. ./latest/
-		git add latest/*
+		publishLatest=false
+		if $publishLatest ; then
+			git rm -rf latest/
+			mkdir -p latest
+			cp -r ../build/docs/. ./latest/
+			git add latest/*
+		fi
 
 		majorVersion=${version:0:4}
 		majorVersion="${majorVersion}x"


### PR DESCRIPTION
The documentation for 3.1.x Shouldn't be published as `latest`  