### PR TITLE
Correct table header syntax error

### DIFF
--- a/src/en/ref/Domain Classes/createCriteria.adoc
+++ b/src/en/ref/Domain Classes/createCriteria.adoc
@@ -62,7 +62,7 @@ Method reference:
 [cols="2*", options="header"]
 |===
 
-|Method,Description
+|Method|Description
 |*list*|The default method; returns all matching rows.
 |*get*|Returns a unique result, i.e. just one row. The criteria has to be formed that way, that it only queries one row. This method is not to be confused with a limit to just the first row.
 |*scroll*|Returns a scrollable result set


### PR DESCRIPTION
Syntax error was causing incorrect table layout resulting in confusing and incorrect method/description alignments for Criteria builder methods.