### PR TITLE
Update unit test directory in Testing documentation introduction

### DIFF
--- a/src/en/guide/testing.adoc
+++ b/src/en/guide/testing.adoc
@@ -7,7 +7,7 @@ The first thing to be aware of is that all of the `create-\*` and `generate-\*` 
 grails create-controller com.acme.app.simple
 ----
 
-Grails will create a controller at `grails-app/controllers/com/acme/app/SimpleController.groovy`, and also a unit test at `test/unit/com/acme/app/SimpleControllerTests.groovy`. What Grails won't do however is populate the logic inside the test! That is left up to you.
+Grails will create a controller at `grails-app/controllers/com/acme/app/SimpleController.groovy`, and also a unit test at `src/test/groovy/com/acme/app/SimpleControllerSpec.groovy`. What Grails won't do however is populate the logic inside the test! That is left up to you.
 
 NOTE: The default class name suffix is `Tests` but as of Grails 1.2.2, the suffix of `Test` is also supported.
 


### PR DESCRIPTION
For Grails 3.2.4, when you create a controller using create-controller, a test is created in the following directory:
```
Created src/test/groovy/com/yourcompany/yourapp/ProductControllerSpec.groovy
```
The example above uses com.yourcompany.yourapp.ProductController as an example. So in general, the path is  **src/test/groovy/something/SomethingSpec.groovy**