### PR TITLE
Add note about Grails 3.x's usage of test-app

### DIFF
--- a/src/en/guide/testing.adoc
+++ b/src/en/guide/testing.adoc
@@ -105,6 +105,8 @@ grails test-app some.org.* SimpleController.testLogin BookController
 
 NOTE: In Grails 2.x, adding `-rerun` as an argument would only run those tests which failed in the previous test-app run. This argument is no longer supported.
 
+NOTE: In Grails 3.x, you might need to specify the package name before the class name, as well as append "Spec" to the end. For example, if you want to run the test for the ProductController, you should use `grails test-app *.ProductControllerSpec`. Note that the star can be used if you don't want to type the whole package hierarchy.
+
 
 ==== Debugging
 


### PR DESCRIPTION
In Grails 3.2.4, for example, to run a specific test, you need to do:
```
grails test-app com.yourcompany.yourapp.ProductControllerSpec
```
In order to run a specific test for, as an example, the ProductController.

Note you need the word **Spec** appended to the end of the class name as well as the specification of the package hierarchy.