### PR TITLE
warn that hilo generator was removed

### DIFF
--- a/src/en/ref/Database Mapping/id.adoc
+++ b/src/en/ref/Database Mapping/id.adoc
@@ -74,3 +74,5 @@ static mapping = {
 ----
 
 See the section on http://gorm.grails.org/6.0.x/hibernate/manual/index.html#identity[Custom Database Identity] in the user guide for more information.
+
+Warning: hilo generator is not supported in Hibernate 5 anymore.


### PR DESCRIPTION
@see org.hibernate.id.factory.internal.DefaultIdentifierGeneratorFactory:
```
public Class getIdentifierGeneratorClass(String strategy) {
		if ( "hilo".equals( strategy ) ) {
			throw new UnsupportedOperationException( "Support for 'hilo' generator has been removed" );
		}
```

in org.hibernate:hibernate-core:5.1.2.Final