### PR TITLE
Update asyncGorm.adoc

### DIFF
--- a/src/en/guide/async/asyncGorm.adoc
+++ b/src/en/guide/async/asyncGorm.adoc
@@ -64,7 +64,7 @@ Instead you need to merge the object with the session bound to the calling threa
 ----
 def promise = Person.async.findByFirstName("Homer")
 def person = promise.get()
-person.merge()
+person = person.merge()
 person.firstName = "Bart"
 ----
 


### PR DESCRIPTION
As noted in https://docs.grails.org/latest/ref/Domain%20Classes/merge.html one needs to use the return value of the call to .merge().