### PR TITLE
Add valueMessagePrefix to fieldValue.adoc

### DIFF
--- a/src/en/ref/Tags/fieldValue.adoc
+++ b/src/en/ref/Tags/fieldValue.adoc
@@ -28,3 +28,4 @@ Attributes
 
 * `bean` (required) - The bean instance to inspect
 * `field` (required) - The name of the field to obtain the value of
+* `valueMessagePrefix` (optional) - Setting this allows the value to be resolved from the I18n messages. The `valueMessagePrefix` will be suffixed with a dot ('.') and then the `field` attribute to resolve the message. If the message cannot be resolved, the value of the field is presented.


### PR DESCRIPTION
The optional valueMessagePrefix was added & merged to the fieldValue tag in grails/grails-core#10527