### PR TITLE
Link to form token now working

### DIFF
--- a/src/en/ref/Tags/form.adoc
+++ b/src/en/ref/Tags/form.adoc
@@ -66,5 +66,5 @@ Attributes
 * `absolute` (optional) - If `true` will prefix the link target address with the value of the `grails.serverURL` property from `application.groovy`, or http://localhost:<port> if there is no setting in `application.groovy` and not running in production.
 * `base` (optional) - Sets the prefix to be added to the link target address, typically an absolute server URL. This overrides the behaviour of the `absolute` property, if both are specified.
 * `name` (optional) - A value to use for both the name and id attribute of the form tag
-* `useToken` (optional) - Set whether to send a token in the request to handle duplicate form submissions. See <<formtokens,Handling Duplicate Form Submissions>>
+* `useToken` (optional) - Set whether to send a token in the request to handle duplicate form submissions. See <<formtokens#,Handling Duplicate Form Submissions>>
 * `method` (optional) - The form method to use, either `POST` or `GET`; defaults to `POST`


### PR DESCRIPTION
Added a # per the ascii doctor documentation:

See the <<README#,README>>.

http://asciidoctor.org/docs/user-manual/#navigating-between-source-files