### PR TITLE
elementId vs id confusion

### DIFF
--- a/src/en/ref/Tags/link.adoc
+++ b/src/en/ref/Tags/link.adoc
@@ -96,8 +96,8 @@ Attributes
 * `resource` (optional)   - the name of the resource url mapping to use in the link; if not specified controller should be used
 * `namespace` (optional) - the namespace of the controller to use in the link
 * `plugin` (optional) - the name of the plugin which provides the controller
-* `elementId` (optional) - this value will be used to populate the `id` attribute of the generated href
-* `id` (optional) - the id to use in the link
+* `elementId` (optional) - this value will be used to populate the `id` attribute of the generated anchor tag
+* `id` (optional) - the id to use in the link href, (often the id param passed to the controller)
 * `fragment` (optional) - The link fragment (often called anchor tag) to use
 * `mapping` (optional) - The <<namedMappings,named URL mapping>> to use to rewrite the link
 * `method` (optional) - The HTTP method specified in the corresponding URL mapping


### PR DESCRIPTION
Just a small change to make things clearer, it seems that in the documentation as it stands that the roles of id and elementId are reversed.  See http://stackoverflow.com/questions/43754126/how-do-i-pass-an-id-to-a-link-when-using-the-method-call-syntax-in-a-taglib/43775473#43775473