### PR TITLE
Adding a subtle but important syntax

### DIFF
--- a/src/en/ref/Tags/createLink.adoc
+++ b/src/en/ref/Tags/createLink.adoc
@@ -77,6 +77,10 @@ results in:
 <a href="/shop/book/list">my link</a>
 ----
 
+Another example with params and href attribute
+----
+<a href="${createLink(controller: 'blah', action: 'moreBlah', params: '[name : "${some.bar}"]')}">
+----
 
 === Description
 


### PR DESCRIPTION
I had to find this obvious syntactical difference while using <g:createLink vs <a tag. What I am referring to is, '=' needs to be replaced with ':' and needs proper quotes. It might be obvious, but not for novice like me.