### PR TITLE
Fix upgrading api links

### DIFF
--- a/src/en/guide/upgrading.adoc
+++ b/src/en/guide/upgrading.adoc
@@ -1,3 +1,6 @@
+:gormapi: http://gorm.grails.org/latest/api
+:api: http://docs.grails.org/latest/api
+
 Grails 3.3 includes several changes to dependencies and Event publishing that may require changes to your application if you are upgrading from Grails 3.2.x.
 
 TIP: For information on upgrading from versions of Grails prior to Grails 3.2.x, see the http://docs.grails.org/3.2.x/guide/upgrading.html[Grails 3.2.x documentation on upgrading]


### PR DESCRIPTION
All api links in http://docs.grails.org/latest/guide/upgrading.html are rendered as ` http://docs.grails.org/latest/guide/%7Bgormapi%7D/org/grails/datastore/mapping/model/MappingContext.html`.