### PR TITLE
Fix typos

### DIFF
--- a/src/en/ref/Controllers/allowedMethods.adoc
+++ b/src/en/ref/Controllers/allowedMethods.adoc
@@ -34,7 +34,7 @@ The `allowedMethods` property provides a simple declarative syntax to specify wh
 
 You can do these checks programmatically in the controller actions and send a 405 error code yourself, but this tends to clutter the controller methods which should focus more on application logic and routing. This approach might not be sufficient in more complex scenarios, and in those cases it's fine to handle things yourself.
 
-The `allowedMethods` property is a Map, where the keys are the names of actions to be restricted and the values are either a `String` or a `List` of `String`s. If the value is a `String`, it represents the only request method that may be used to invoke that action. If it is a `List` of `String`s the `List` it represents all of the request methods that may be used to invoke that action. If the specified restrictions are violated then a 405 error code is returned in the response.
+The `allowedMethods` property is a Map, where the keys are the names of actions to be restricted and the values are either a `String` or a `List` of `String`. If the value is a `String`, it represents the only request method that may be used to invoke that action. If it is a `List` of `String`, it represents all of the request methods that may be used to invoke that action. If the specified restrictions are violated then a 405 error code is returned in the response.
 
 For example this code prevents the `delete` action from being invoked using an HTTP GET:
 


### PR DESCRIPTION
The `String`s notation wasn't rendering correctly. Removed the s as it seems we cannot have only part of a word monospaced.