### PR TITLE
Render list in note about parsing request body.

### DIFF
--- a/src/en/guide/theWebLayer/controllers/commandObjects.adoc
+++ b/src/en/guide/theWebLayer/controllers/commandObjects.adoc
@@ -204,10 +204,14 @@ $ curl -H "Content-Type: application/xml" -d '<widget><name>Some Other Widget</n
  Name: Some Other Widget, Size: 2112
 ----
 
-NOTE: The request body will not be parsed under the following conditions:
-* The request method is GET
-* The request method is DELETE
-* The content length is 0
+[NOTE]
+====
+The request body will not be parsed under the following conditions:
+
+    * The request method is GET
+    * The request method is DELETE
+    * The content length is 0
+====
 
 Note that the body of the request is being parsed to make that work.  Any attempt to read the body of the request after that will fail since the corresponding input stream will be empty.  The controller action can either use a command object or it can parse the body of the request on its own (either directly, or by referring to something like request.JSON), but cannot do both.
 


### PR DESCRIPTION
It looks like the items are intended to be rendered as a bulleted list but do not use the necessary markup.