### PR TITLE
Update restfulMappings.adoc

### DIFF
--- a/src/en/guide/theWebLayer/urlmappings/restfulMappings.adoc
+++ b/src/en/guide/theWebLayer/urlmappings/restfulMappings.adoc
@@ -168,7 +168,7 @@ As a convenience you can also pass a domain instance to the `resource` attribute
 
 [source,groovy]
 ----
-<g:link resource="${book}">My Link</g:link>
+<g:link resource="${book}" method="GET">My Link</g:link>
 ----
 
 This will automatically produce the correct link (in this case "/books/1" for an id of "1").


### PR DESCRIPTION
It is necessary to add the method attribute in order to produce the correct url

Without method i get a result like this
`http://localhost:8000/book?id=8`

With method attribute i get the expected result
`http://localhost:8000/books/8`