### PR TITLE
Update readingMessages.adoc

### DIFF
--- a/src/en/guide/i18n/readingMessages.adoc
+++ b/src/en/guide/i18n/readingMessages.adoc
@@ -13,7 +13,7 @@ As long as you have a key in your `messages.properties` (with appropriate locale
 
 [source,groovy]
 ----
-my.localized.content=Hola, Me llamo John. Hoy es domingo.
+my.localized.content=Hola, me llamo John. Hoy es domingo.
 ----
 
 Messages can also include arguments, for example:
@@ -27,7 +27,7 @@ The message declaration specifies positional parameters which are dynamically sp
 
 [source,groovy]
 ----
-my.localized.content=Hola, Me llamo {0}. Hoy es {1}.
+my.localized.content=Hola, me llamo {0}. Hoy es {1}.
 ----
 
 ==== Reading Messages in Grails Artifacts with MessageSource


### PR DESCRIPTION
Not important stuff but, in Spanish, next word after a comma is not capitalized