### PR TITLE
Updated save.adoc - flush description for transactions

### DIFF
--- a/src/en/ref/Domain Classes/save.adoc
+++ b/src/en/ref/Domain Classes/save.adoc
@@ -43,7 +43,7 @@ if (!b.save()) {
 Parameters:
 
 * `validate` (optional) - Set to `false` if validation should be skipped
-* `flush` (optional) - When set to `true` flushes the persistence context, persisting the object immediately and updating the `version` column for http://gorm.grails.org/6.0.x/hibernate/manual/index.html#locking[optimistic locking]
+* `flush` (optional) - When set to `true` flushes the persistence context, persisting the object immediately and updating the `version` column for http://gorm.grails.org/6.0.x/hibernate/manual/index.html#locking[optimistic locking]. Inside a transaction the persisted changes are not committed (and thus not visible to other transactions) until the end of the transaction.
 * `insert` (optional) - When set to `true` will force Hibernate to do a SQL INSERT; this is useful in certain situations (for example when using assigned ids) and Hibernate cannot detect whether to do an INSERT or an UPDATE
 * `failOnError` (optional) - When set to `true` the `save` method with throw a `grails.validation.ValidationException` if link:{guidePath}/validation.html[validation] fails. This behavior may also be triggered by setting the `grails.gorm.failOnError` property in `grails-app/conf/application.groovy`. If the Config property is set and the argument is passed to the method, the method argument will always take precedence.  For more details about the config property and other GORM config options, see the link:{guidePath}/conf.html#configGORM[GORM Configuration Options] section of The User Guide.
 * `deepValidate` (optional) - Determines whether associations of the domain instance should also be validated, i.e. whether validation cascades. This is `true` by default - set to `false` to disable cascading validation.


### PR DESCRIPTION
Updated documentation of the save(flush: true) behaviour description inside transactions