### PR TITLE
Add note about return value for `handle`

### DIFF
--- a/src/en/guide/commandLine/creatingCustomCommands.adoc
+++ b/src/en/guide/commandLine/creatingCustomCommands.adoc
@@ -5,7 +5,7 @@ You can create your own commands by running the <<ref-command-line-create-comman
 ----
 grails create-command HelloWorld
 ----
-
+to
 NOTE: Unlike scripts, commands cause the Grails environment to start and you have full access to the application context and the runtime.
 
 Since Grails 3.2.0, commands have similar abilities as scripts in regards to retrieving arguments, template generation, file access, and model building.
@@ -19,7 +19,7 @@ Commands created in Grails 3.1.x or lower implement the http://docs.grails.org/l
 boolean handle(ExecutionContext executionContext)
 ----
 
-The implementation of `handle` should return `true` if command execution was successful and `false` otherse.
+The implementation of `handle` should return `true` if command execution was successful and `false` otherwise.
 
 Commands created in Grails 3.2.0 or higher implement the http://docs.grails.org/latest/api/grails/dev/commands/GrailsApplicationCommand.html[GrailsApplicationCommand] trait by default which requires your command to implement the following method:
 

--- a/src/en/guide/commandLine/creatingCustomCommands.adoc
+++ b/src/en/guide/commandLine/creatingCustomCommands.adoc
@@ -5,7 +5,7 @@ You can create your own commands by running the <<ref-command-line-create-comman
 ----
 grails create-command HelloWorld
 ----
-to
+
 NOTE: Unlike scripts, commands cause the Grails environment to start and you have full access to the application context and the runtime.
 
 Since Grails 3.2.0, commands have similar abilities as scripts in regards to retrieving arguments, template generation, file access, and model building.

--- a/src/en/guide/commandLine/creatingCustomCommands.adoc
+++ b/src/en/guide/commandLine/creatingCustomCommands.adoc
@@ -19,14 +19,18 @@ Commands created in Grails 3.1.x or lower implement the http://docs.grails.org/l
 boolean handle(ExecutionContext executionContext)
 ----
 
+The implementation of `handle` should return `true` if command execution was successful and `false` otherse.
+
 Commands created in Grails 3.2.0 or higher implement the http://docs.grails.org/latest/api/grails/dev/commands/GrailsApplicationCommand.html[GrailsApplicationCommand] trait by default which requires your command to implement the following method:
 
 [source,groovy]
 ----
 boolean handle()
 ----
-
+  
 NOTE: Commands defined this way still have access to the execution context via a variable called "executionContext".
+
+As before, the implementation of `handle` should return `true` if successful and `false` otherwise.
 
 Custom commands can be executed using *grails run-command*:
 


### PR DESCRIPTION
Add note about the return value for the `handle` method in both `ApplicationCommand` and `GrailsApplicationCommand`, indicating that successful command execution should return true, and false otherwise.