### PR TITLE
wrong url plugin portal website

### DIFF
--- a/src/en/guide/plugins/repositories.adoc
+++ b/src/en/guide/plugins/repositories.adoc
@@ -18,4 +18,4 @@ grails plugin-info [plugin-name]
 
 which prints extra information about it, such as its description, who wrote, etc.
 
-NOTE: If you have created a Grails plugin and want it to be hosted in the central repository, you'll find instructions for getting an account on the http://grails.org/plugins.html[plugin portal] website.
+NOTE: If you have created a Grails plugin and want it to be hosted in the central repository, you'll find instructions for getting an account on the https://grails.org/plugins/[plugin portal] website.

--- a/src/en/guide/plugins/repositories.adoc
+++ b/src/en/guide/plugins/repositories.adoc
@@ -18,4 +18,4 @@ grails plugin-info [plugin-name]
 
 which prints extra information about it, such as its description, who wrote, etc.
 
-NOTE: If you have created a Grails plugin and want it to be hosted in the central repository, you'll find instructions for getting an account on the https://grails.org/plugins/[plugin portal] website.
+NOTE: If you have created a Grails plugin and want it to be hosted in the central repository, you'll find instructions for getting an account on the http://plugins.grails.org/[plugin portal] website.


### PR DESCRIPTION
I think new url is https://grails.org/plugins/