### PR TITLE
Tweaked usage pattern

### DIFF
--- a/src/en/ref/Command Line/run-app.adoc
+++ b/src/en/ref/Command Line/run-app.adoc
@@ -21,7 +21,7 @@ Usage:
 
 [source,groovy]
 ----
-grails <<env>>* run-app
+grails [-Dgrails.env=<<env>>] run-app
 ----
 
 Arguments:


### PR DESCRIPTION
"grails production run-app" does not actually work. Use "grails -Dgrails.env=production run-app".