### PR TITLE
Fix broken link to GSP documentation

### DIFF
--- a/src/en/guide/i18n/readingMessages.adoc
+++ b/src/en/guide/i18n/readingMessages.adoc
@@ -49,7 +49,7 @@ class MyappController {
 
 ==== Reading Messages in Controllers and Tag Libraries with the Message Tag
 
-Additionally, you can read a message inside Controllers and Tag Libraries with the link:http://docs.grails.org/latest/ref/Tags/message.html[Message Tag]. However, using the message tag relies on GSP support which a Grails application may not necessarily have; e.g. a rest application.
+Additionally, you can read a message inside Controllers and Tag Libraries with the link:http://gsp.grails.org/latest/ref/Tags/message.html[Message Tag]. However, using the message tag relies on GSP support which a Grails application may not necessarily have; e.g. a rest application.
 
 In a controller, you can invoke tags as methods.
 


### PR DESCRIPTION
Following the separation of the GSP documentation from the Grails documentation, the link to the documentation for the Message Tag is broken...