### PR TITLE
Update providingBasicArtefacts.adoc

### DIFF
--- a/src/en/guide/plugins/providingBasicArtefacts.adoc
+++ b/src/en/guide/plugins/providingBasicArtefacts.adoc
@@ -117,7 +117,7 @@ By default Grails excludes the following files during the packaging process:
 * SCM management files within `\*\*/.svn/\*\*` and `\*\*/CVS/\*\*`
 
 
-In addition, the default `UrlMappings.groovy` file is excluded to avoid naming conflicts, however you are free to add a UrlMappings definition under a different name which *will* be included. For example a file called `grails-app/controllers/BlogUrlMappings.groovy` is fine.
+The default `UrlMappings.groovy` file is not excluded, so remove any mappings that are not required for the plugin to work.  You are also free to add a UrlMappings definition under a different name which *will* be included. For example a file called `grails-app/controllers/BlogUrlMappings.groovy` is fine.
 
 The list of excludes is extensible with the `pluginExcludes` property:
 


### PR DESCRIPTION
Per discussion with David Estes during a G3 summit presentation, the UrlMappings.groovy file IS included by default.  Apparently this is different behavior than in Grails 2.