### PR TITLE
Allow generation of partial URIs for redirect

### DIFF
--- a/src/en/ref/Controllers/redirect.adoc
+++ b/src/en/ref/Controllers/redirect.adoc
@@ -62,6 +62,6 @@ class SomeController {
 * `mapping` (optional) - The <<namedMappings,named URL mapping>> to use to rewrite the link
 * `params` (optional) - a map containing request parameters
 * `url` (optional) - a map containing the action, controller, id etc.
-* `absolute` (optional) - If `true` will prefix the link target address with the value of the `grails.serverURL` property from `application.groovy`, or http://localhost:<port> if there is no value in `application.groovy` and not running in the production environment.
+* `absolute` (optional) - If `true` (default) will prefix the link target address with the value of the `grails.serverURL` property from `application.groovy`, or http://localhost:<port> if there is no value in `application.groovy` and not running in the production environment. If `false` a partial URI is generated for the `Location` header.
 * `base` (optional) - Sets the prefix to be added to the link target address, typically an absolute server URL. This overrides the behaviour of the `absolute` property if both are specified.
 * `permanent` (optional) - If `true` the redirect will be issued with a 301 HTTP status code (permanently moved), otherwise a 302 HTTP status code will be issued


### PR DESCRIPTION
Updated documentation explaining behavior for partial URI redirects. This needs to be merged with https://github.com/grails/grails-core/pull/10910

Btw, I've created this branch from `master` because I haven't found a branch from `3.3.x` and I'm not really sure from which commit I should create (if needed) that branch.