### PR TITLE
3.2.x Resizing the topics on "Attributes" section for "Tags" page

### DIFF
--- a/src/en/ref/Tags/each.adoc
+++ b/src/en/ref/Tags/each.adoc
@@ -73,8 +73,8 @@ Using the status parameter to alternate the coloring of a table's rows:
 
 Attributes
 
-# `in` - The object to iterate over
-# `status` (optional) - The name of a variable to store the iteration index in. Starts with 0 and increments for each iteration. If this parameter is used, then `var` is required.
-# `var` (optional) - The name of the item, defaults to "it".
+* `in` - The object to iterate over
+* `status` (optional) - The name of a variable to store the iteration index in. Starts with 0 and increments for each iteration. If this parameter is used, then `var` is required.
+* `var` (optional) - The name of the item, defaults to "it".
 
 NOTE: Note that `var` attribute must be specified when the iterator value is to be used from within the body of a GSP Dynamic Tag, such as in `<g:link>`.


### PR DESCRIPTION
Attributes on page "Tags" are too big. According to another pages it shouldn't be so big.