### PR TITLE
Update upgrading.adoc

### DIFF
--- a/src/en/guide/upgrading.adoc
+++ b/src/en/guide/upgrading.adoc
@@ -131,9 +131,11 @@ If you are upgrading and have referenced any of these dependencies in your appli
 
 === Spring Boot 1.5.x
 
-Spring Boot 1.5.x removes a number of deprecated classes, notably all of the classes within the `org.springframework.boot.context.embedded` package.
+Spring Boot 1.5.x removes a number of deprecated classes, notably several of the classes within the `org.springframework.boot.context.embedded` package.
 
 If your application is referencing any of the classes within this package you will need to alter your imports to use `org.springframework.boot.web.servlet` instead.
+
+All classes in the `org.springframework.boot.context.web` package have been deprecated and relocated per the Spring Boot 1.4 Release Notes.
 
 === Reactor 2.x Deprecated and Removed
 


### PR DESCRIPTION
Not all of the classes in the `org.springframework.boot.context.embedded` package were deprecated per the doc at https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-1.4-Release-Notes. All of the classes in the `org.springframework.boot.context.web` package were deprecated. Looks like typo.