### PR TITLE
Dependency exclusions need to indicate a version

### DIFF
--- a/src/en/guide/profiles/profileStructure.adoc
+++ b/src/en/guide/profiles/profileStructure.adoc
@@ -93,7 +93,7 @@ A map of scopes and dependencies to configure. The `excludes` scope can be used 
 ----
 dependencies:
     excludes:
-        - "org.grails:hibernate"
+        - "org.grails:hibernate:*"
     build:
         - "org.grails:grails-gradle-plugin:$grailsVersion" 
     compile:


### PR DESCRIPTION
The trick is to use `*` as version