### PR TITLE
Updated single resource property to single

### DIFF
--- a/src/en/guide/theWebLayer/urlmappings/restfulMappings.adoc
+++ b/src/en/guide/theWebLayer/urlmappings/restfulMappings.adoc
@@ -64,11 +64,11 @@ Notice how the HTTP method name is prefixed prior to each URL mapping definition
 ==== Single resources
 
 
-A single resource is a resource for which there is only one (possibly per user) in the system. You can create a single resource using the `resource` parameter (as opposed to `resources`):
+A single resource is a resource for which there is only one (possibly per user) in the system. You can create a single resource using the `single` parameter (as opposed to `resources`):
 
 [source,groovy]
 ----
-"/book"(resource:'book')
+"/book"(single:'book')
 ----
 
 This results in the following URL mappings:


### PR DESCRIPTION
According to deprecation warning the `resource` property is being replaced with `single` for what i assume is clarity.