### PR TITLE
Add documentation for runtime.groovy

### DIFF
--- a/src/en/guide/conf/config.adoc
+++ b/src/en/guide/conf/config.adoc
@@ -2,7 +2,7 @@ Configuration in Grails is generally split across 2 areas: build configuration a
 
 Build configuration is generally done via Gradle and the `build.gradle` file. Runtime configuration is by default specified in YAML in the `grails-app/conf/application.yml` file.
 
-If you prefer to use Grails 2.0-style Groovy configuration then it is possible to specify configuration using Groovy's http://docs.groovy-lang.org/latest/html/documentation/#_configslurper[ConfigSlurper] syntax. Two Groovy configuration files are available: `grails-app/conf/application.config` and `grails-app/conf/runtime.config`:
+If you prefer to use Grails 2.0-style Groovy configuration then it is possible to specify configuration using Groovy's http://docs.groovy-lang.org/latest/html/documentation/#_configslurper[ConfigSlurper] syntax. Two Groovy configuration files are available: `grails-app/conf/application.groovy` and `grails-app/conf/runtime.groovy`:
 
 . Use `application.groovy` for configuration that doesn't depend on application classes
 . Use `runtime.groovy` for configuration that does depend on application classes

--- a/src/en/guide/conf/config.adoc
+++ b/src/en/guide/conf/config.adoc
@@ -2,7 +2,19 @@ Configuration in Grails is generally split across 2 areas: build configuration a
 
 Build configuration is generally done via Gradle and the `build.gradle` file. Runtime configuration is by default specified in YAML in the `grails-app/conf/application.yml` file.
 
-If you prefer to use Grails 2.0-style Groovy configuration then you can create an additional `grails-app/conf/application.groovy` file to specify configuration using Groovy's http://docs.groovy-lang.org/latest/html/documentation/#_configslurper[ConfigSlurper] syntax.
+If you prefer to use Grails 2.0-style Groovy configuration then it is possible to specify configuration using Groovy's http://docs.groovy-lang.org/latest/html/documentation/#_configslurper[ConfigSlurper] syntax. Two Groovy configuration files are available: `grails-app/conf/application.config` and `grails-app/conf/runtime.config`:
+
+. Use `application.groovy` for configuration that doesn't depend on application classes
+. Use `runtime.groovy` for configuration that does depend on application classes
+
+[NOTE]
+====
+This separation is necessary because configuration values defined in `application.groovy` are available to the Grails CLI, which needs to be able to load `application.groovy` before the application has been compiled. References to application classes in `application.groovy` will cause an exception when these commands are executed by the CLI:
+----
+Error occurred running Grails CLI: 
+startup failed:script14738267015581837265078.groovy: 13: unable to resolve class com.foo.Bar
+----
+====
 
 For Groovy configuration the following variables are available to the configuration script:
 


### PR DESCRIPTION
`runtime.groovy` was introduced in Grails 3.2 in response to https://github.com/grails/grails-core/issues/10131 but was only documented in the upgrade notes, and has therefore disappeared from the latest version of the documentation.

The existence of `runtime.groovy` and the reason why it is required should be documented in the Configuration chapter.