### PR TITLE
Include example of using -port

### DIFF
--- a/src/en/ref/Command Line/run-app.adoc
+++ b/src/en/ref/Command Line/run-app.adoc
@@ -13,6 +13,7 @@ WARNING: This target is _not_ intended to be used for application deployment. Th
 grails run-app
 grails run-app -https // with HTTPS
 grails test run-app
+grails dev run-app -port=8090
 ----
 
 === Description


### PR DESCRIPTION
Included an example of how to use the -port argument when using run-app from the command line.