### PR TITLE
Clarified default behavior for create-plugin

### DIFF
--- a/src/en/guide/plugins/creatingAndInstallingPlugins.adoc
+++ b/src/en/guide/plugins/creatingAndInstallingPlugins.adoc
@@ -9,9 +9,9 @@ Creating a Grails plugin is a simple matter of running the command:
 grails create-plugin <<PLUGIN NAME>>
 ----
 
-This will create a plugin project for the name you specify. For example running `grails create-plugin example` would create a new plugin project called `example`.
+This will create a web-plugin project for the name you specify. For example running `grails create-plugin example` would create a new web-plugin project called `example`.
 
-In Grails 3.0 you should consider whether the plugin you create requires a web environment or whether the plugin can be used with other profiles. If your plugin does not require a web environment then use the "plugin" profile instead of the "web-plugin" profile:
+In Grails 3.0 you should consider whether the plugin you create requires a web environment or whether the plugin can be used with other profiles. If your plugin does not require a web environment then use the "plugin" profile instead of the default "web-plugin" profile:
 
 [source,groovy]
 ----


### PR DESCRIPTION
Ie. documented that create-plugin utilizes the web-plugin profile by default.
(Current behavior in Grails v3.3.5)