### PR TITLE
grails-test-mixins 3.3.0.RC1 -> 3.3.0

### DIFF
--- a/src/en/guide/testing/unitTesting.adoc
+++ b/src/en/guide/testing/unitTesting.adoc
@@ -28,7 +28,7 @@ Versions of Grails below 3.2 used the https://grails-plugins.github.io/grails-te
 .build.gradle
 [source,groovy]
 ----
-testCompile "org.grails:grails-test-mixins:3.3.0.RC1"
+testCompile "org.grails:grails-test-mixins:3.3.0"
 ----
 
 This may be useful if you are, for example, upgrading an existing application to Grails 3.3.x.


### PR DESCRIPTION
Reference a stable version.