### PR TITLE
Add header method to Controller in quick reference 

### DIFF
--- a/src/en/ref/Controllers/header.adoc
+++ b/src/en/ref/Controllers/header.adoc
@@ -1,0 +1,29 @@
+
+== header
+
+
+
+=== Purpose
+
+
+To add a header to the response.
+
+
+=== Examples
+
+
+[source,groovy]
+----
+// Adds a header to the response
+header 'Cache-Control', 'max-age=84600, public'
+----
+
+
+=== Description
+
+A method to add headers to the response.
+
+Parameters:
+
+* `headerName` - The header name to add
+* `headerValue` - The header value to add

--- a/src/en/ref/Controllers/header.adoc
+++ b/src/en/ref/Controllers/header.adoc
@@ -23,7 +23,7 @@ header 'Cache-Control', 'max-age=84600, public'
 
 A method to add headers to the response.
 
-Parameters:
+=== Parameters:
 
 * `headerName` - The header name to add
 * `headerValue` - The header value to add


### PR DESCRIPTION
The `header` method is a way to add response headers from Controller methods; this should document it.
