### PR TITLE
Update scaffolding.adoc

### DIFF
--- a/src/en/guide/scaffolding.adoc
+++ b/src/en/guide/scaffolding.adoc
@@ -81,9 +81,9 @@ class BookController {
 
     // overrides scaffolded action to return both authors and books
     def index() {
-        [bookInstanceList: Book.list(),
-         bookInstanceTotal: Book.count(),
-         authorInstanceList: Author.list()]
+        [bookList: Book.list(),
+         bookTotal: Book.count(),
+         authorList: Author.list()]
     }
 
     def show() {


### PR DESCRIPTION
Updated doc to reflect variable names changes in views. It looks like "Instance" is no longer part of the view's variable names in Grails 3