### PR TITLE
Add section on the pathingJar for Windows users

### DIFF
--- a/src/en/guide/gettingStarted/aHelloWorldExample.adoc
+++ b/src/en/guide/gettingStarted/aHelloWorldExample.adoc
@@ -58,6 +58,8 @@ With the above configuration in place the server will instead startup at the URL
 
 NOTE: If you see the error "Server failed to start for port 8080: Address already in use", then it means another server is running on that port. You can easily work around this by running your server on a different port using `run-app -port=9090`. '9090' is just an example: you can pretty much choose anything within the range 1024 to 49151.
 
+NOTE: On Windows, if you see the error "> A problem occurred starting process 'command 'C:\path\to\java.exe''", run it again with the `--stacktrace` flag. If the root error is "Caused by: java.io.IOException: CreateProcess error=206, The filename or extension is too long", add `grails { pathingJar = true }` to your `build.gradle` file. This is a known limitation with Windows.
+
 The result will look something like this:
 
 image::intropage.png[]


### PR DESCRIPTION
This is a common issue Windows users will encounter, especially when running a sample application.

I'm open to wording it differently if you like. This feature seems important enough to warrant its inclusion in the guide.

Hopefully this mitigates https://github.com/grails/grails-core/issues/10646 by pointing first-time Windows users in the right direction.