### PR TITLE
Update databaseConsole.adoc

### DIFF
--- a/src/en/guide/conf/dataSource/databaseConsole.adoc
+++ b/src/en/guide/conf/dataSource/databaseConsole.adoc
@@ -2,8 +2,26 @@ The http://h2database.com/html/quickstart.html#h2_console[H2 database console] i
 
 You can access the console by navigating to http://localhost:8080/dbconsole in a browser. The URI can be configured using the `grails.dbconsole.urlRoot` attribute in `application.groovy` and defaults to `'/dbconsole'`.
 
-The console is enabled by default in development mode and can be disabled or enabled in other environments by using the `grails.dbconsole.enabled` attribute in `application.groovy`. For example, you could enable the console in production like this:
+The console is enabled by default in development mode and can be disabled or enabled in other environments by using the `grails.dbconsole.enabled` attribute in `application.yml` (or `application.groovy` for Grails 2.x). For example, you could enable the console in production like this:
 
+[source,yaml]
+----
+environments:
+    production:
+        grails:
+            serverUrl: "http://www.changeme.com"
+            dbconsole:
+                enabled: true
+                urlRoot: '/admin/dbconsole'
+    development:
+        grails:
+            serverUrl: "http://localhost:8080/${appName}"
+    test:
+        grails:
+            serverUrl: "http://localhost:8080/${appName}"
+----
+
+or for `application.groovy`:
 [source,groovy]
 ----
 environments {


### PR DESCRIPTION
`application.groovy` is for Grails 2.x, not 3.3.x which this documentation is on. Can you please consider this change to avoid any confusion for new learners like myself?