### PR TITLE
update 3.3.x doc to refer to `application.yml` config

### DIFF
--- a/src/en/guide/conf/dataSource/databaseConsole.adoc
+++ b/src/en/guide/conf/dataSource/databaseConsole.adoc
@@ -15,10 +15,10 @@ environments:
                 urlRoot: '/admin/dbconsole'
     development:
         grails:
-            serverUrl: "http://localhost:8080/${appName}"
+            serverUrl: "http://localhost:8080/${info.app.name}"
     test:
         grails:
-            serverUrl: "http://localhost:8080/${appName}"
+            serverUrl: "http://localhost:8080/${info.app.name}"
 ----
 
 or for `application.groovy`:

--- a/src/en/guide/conf/dataSource/databaseConsole.adoc
+++ b/src/en/guide/conf/dataSource/databaseConsole.adoc
@@ -2,8 +2,26 @@ The http://h2database.com/html/quickstart.html#h2_console[H2 database console] i
 
 You can access the console by navigating to http://localhost:8080/dbconsole in a browser. The URI can be configured using the `grails.dbconsole.urlRoot` attribute in `application.groovy` and defaults to `'/dbconsole'`.
 
-The console is enabled by default in development mode and can be disabled or enabled in other environments by using the `grails.dbconsole.enabled` attribute in `application.groovy`. For example, you could enable the console in production like this:
+The console is enabled by default in development mode and can be disabled or enabled in other environments by using the `grails.dbconsole.enabled` attribute in `application.yml` (or `application.groovy` for Grails 2.x). For example, you could enable the console in production like this:
 
+[source,yaml]
+----
+environments:
+    production:
+        grails:
+            serverUrl: "http://www.changeme.com"
+            dbconsole:
+                enabled: true
+                urlRoot: '/admin/dbconsole'
+    development:
+        grails:
+            serverUrl: "http://localhost:8080/${appName}"
+    test:
+        grails:
+            serverUrl: "http://localhost:8080/${appName}"
+----
+
+or for `application.groovy`:
 [source,groovy]
 ----
 environments {


### PR DESCRIPTION
this part of the doc only has Grail 2.0-style `application.groovy` example but not `application.yml` for Grails 3.x - so adding it here