### PR TITLE
Improve wording regarding JAVA_HOME requirements

### DIFF
--- a/src/en/guide/gettingStarted/requirements.adoc
+++ b/src/en/guide/gettingStarted/requirements.adoc
@@ -2,7 +2,7 @@ Before installing Grails 3.0 you will need as a minimum a Java Development Kit (
 
 To automate the installation of Grails we recommend http://sdkman.io[SDKMAN] which greatly simplifies installing and managing multiple Grails versions.
 
-On some platforms (for example OS X) the Java installation is automatically detected. However in many cases you will want to manually configure the location of Java. For example, if you're using bash or another variant of the Bourne Shell:
+On some platforms (for example macOS) the Java installation is automatically detected. However for certain features to work you must manually configure the location of Java. For example, if you're using bash or another variant of the Bourne Shell:
 
 [source,bash]
 ----


### PR DESCRIPTION
For JMX connector features to work (such as stop-app) the JAVA_HOME environment variable must be set, so include that wording.

Addresses the cause of https://github.com/grails/grails-core/issues/11119, which can be confusing to someone just encountering it.