### PR TITLE
Update run-app.adoc

### DIFF
--- a/src/en/ref/Command Line/run-app.adoc
+++ b/src/en/ref/Command Line/run-app.adoc
@@ -46,4 +46,4 @@ This command starts Grails in an embedded servlet container that can serve HTTP 
 runtime "org.springframework.boot:spring-boot-starter-jetty"
 ----
 
-For more information see the Spring Boot documentation on http://docs.spring.io/spring-boot/docs/current/reference/html/howto-embedded-servlet-containers.html[Embedded Containers].
+For more information see the Spring Boot documentation on https://docs.spring.io/spring-boot/docs/current/reference/html/howto-embedded-web-servers.html[Embedded Containers].


### PR DESCRIPTION
In this proposal I've kept the term "Embedded containers" even though Spring Boot mostly seems to refer to "Embedded web servers". At least with regards to changing between servers. To adhere to Spring Boot documentation changing to the latter might be a good idea in this section, however with this minor change at least the user is sent to the relevant URL and not a 404 page.