### PR TITLE
Update Grails version from 3.3.2 to 4.0.0 M1

### DIFF
--- a/src/en/guide/gettingStarted/requirements.adoc
+++ b/src/en/guide/gettingStarted/requirements.adoc
@@ -1,4 +1,4 @@
-Before installing Grails 3.3.2 you will need as a minimum a Java Development Kit (JDK) installed version 1.7 or above. Download the appropriate JDK for your operating system, run the installer, and then set up an environment variable called `JAVA_HOME` pointing to the location of this installation.
+Before installing Grails 4.0.0 M1 you will need as a minimum a Java Development Kit (JDK) installed version 1.7 or above. Download the appropriate JDK for your operating system, run the installer, and then set up an environment variable called `JAVA_HOME` pointing to the location of this installation.
 
 To automate the installation of Grails we recommend http://sdkman.io[SDKMAN] which greatly simplifies installing and managing multiple Grails versions.
 


### PR DESCRIPTION
In addition to this, what is the minimum JDK for Grails 4?  I am successfully running it under 1.8.  Just want to confirm that the above 1.7 reference is not an artifact of the 3.3.2 requirements.