### PR TITLE
Remove repeated 'by default'

### DIFF
--- a/src/en/guide/conf/dataSource/multipleDatasources.adoc
+++ b/src/en/guide/conf/dataSource/multipleDatasources.adoc
@@ -243,7 +243,7 @@ If you have a `Foo` domain class in `dataSource1` and a `Bar` domain class in `d
 
 ==== Transactions across multiple data sources
 
-Grails does not by default by default try to handle transactions that span multiple data sources.
+Grails does not by default try to handle transactions that span multiple data sources.
 
 You can enable Grails to use the Best Effort 1PC pattern for handling transactions across multiple datasources. To do so you must set the `grails.transaction.chainedTransactionManagerPostProcessor.enabled` setting to `true` in `application.yml`:
 


### PR DESCRIPTION
Remove repeated 'by default' from multipleDatasources.adoc

Somehow github is showing a difference on line 288 as well, nothing changed there.