### PR TITLE
render.adoc: Use double quotes for GString

### DIFF
--- a/src/en/ref/Controllers/render.adoc
+++ b/src/en/ref/Controllers/render.adoc
@@ -58,7 +58,7 @@ render(contentType: "application/json") {
 }
 
 // render with status code
-render(status: 503, text: 'Failed to update book ${b.id}')
+render(status: 503, text: "Failed to update book ${b.id}")
 
 // render a file
 render(file: new File(absolutePath), fileName: "book.pdf")


### PR DESCRIPTION
Render with status code + text suggests a use of string interpolation in the text string. It can not be done in a plain Java String defined with simple quotes: use double quotes instead