### PR TITLE
Update upgrading.adoc

### DIFF
--- a/src/en/guide/upgrading.adoc
+++ b/src/en/guide/upgrading.adoc
@@ -18,7 +18,7 @@ Grails 4 app's `gradle.properties`
 .gradle.properties
 ----
 ...
-grailsVersion=4.0.0.BUILD-SNAPSHOT
+grailsVersion=4.0.0
 ...
 ----
 
@@ -42,7 +42,7 @@ Grails 4 app's `gradle.properties`
 .gradle.properties
 ----
 ...
-gormVersion=7.0.0.RC1
+gormVersion=7.0.2
 ...
 ----
 


### PR DESCRIPTION
The versions near the top were leftover from snapshot builds. I updated with the versions I observed when I created a new project in the Grails 4 release version.