### PR TITLE
Remove autoFlush

### DIFF
--- a/src/en/guide/conf/config/configGORM.adoc
+++ b/src/en/guide/conf/config/configGORM.adoc
@@ -21,5 +21,3 @@ grails:
             - com.companyname.somepackage
             - com.companyname.someotherpackage
 ----
-
-* `grails.gorm.autoFlush` - If set to `true`, causes the link:../ref/Domain%20Classes/merge.html[merge], link:../ref/Domain%20Classes/save.html[save] and link:../ref/Domain%20Classes/delete.html[delete] methods to flush the session, replacing the need to explicitly flush using `save(flush: true)`.


### PR DESCRIPTION
autoFlush is deprecated according to http://gorm.grails.org/snapshot/mongodb/api/org/grails/datastore/mapping/core/connections/ConnectionSourceSettings.html#autoFlush