### PR TITLE
Update transactionAwareDataSourceProxy.adoc

### DIFF
--- a/src/en/guide/conf/dataSource/transactionAwareDataSourceProxy.adoc
+++ b/src/en/guide/conf/dataSource/transactionAwareDataSourceProxy.adoc
@@ -1,23 +1,3 @@
 The actual `dataSource` bean is wrapped in a transaction-aware proxy so you will be given the connection that's being used by the current transaction or Hibernate `Session` if one is active.
 
 If this were not the case, then retrieving a connection from the `dataSource` would be a new connection, and you wouldn't be able to see changes that haven't been committed yet (assuming you have a sensible transaction isolation setting, e.g. `READ_COMMITTED` or better).
-
-The "real" unproxied `dataSource` is still available to you if you need access to it; its bean name is `dataSourceUnproxied`.
-
-You can access this bean like any other Spring bean, i.e. using dependency injection:
-
-[source,groovy]
-----
-class MyService {
-
-   def dataSourceUnproxied
-   ...
-}
-----
-
-or by pulling it from the `ApplicationContext`:
-
-[source,groovy]
-----
-def dataSourceUnproxied = ctx.dataSourceUnproxied
-----


### PR DESCRIPTION
According to http://docs.grails.org/3.3.x/guide/upgrading.html, dataSourceUnproxied has been removed previously.