### PR TITLE
Found Wrong Dependency Name in grails 4.0.1 docs under heading "Content Negotiation using the format Request Parameter"

### DIFF
--- a/src/en/guide/theWebLayer/contentNegotiation.adoc
+++ b/src/en/guide/theWebLayer/contentNegotiation.adoc
@@ -86,7 +86,7 @@ You can also define this parameter in the link:theWebLayer.html#urlmappings[URL 
 
 You could code your controller action to return XML based on this property, but you can also make use of the controller-specific `withFormat()` method:
 
-NOTE: This example requires the addition of the `org.grails.plugins:grails-plugin-converters` plugin
+NOTE: This example requires the addition of the `org.grails.plugins:converters` plugin
 
 [source,groovy]
 ----


### PR DESCRIPTION
 I have found a mistake in grails 4,0,1 guide according to the guide we have to add  `org.grails.plugins:grails-plugin-converters` this dependency for working with different type of responses. as you can see in given link under section Content Negotiation using the format Request Parameter
https://docs.grails.org/4.0.1/guide/single.html
but when i try to use the above dependency it does not work showing error to me `Error initializing classpath: Could not find :grails-plugin-converters:_` now i searched on google and find that the correct dependency for grails 3.3.x or above is `org.grails.plugins:converters`.