### PR TITLE
Set gradle.properties before calling ./gradlew

### DIFF
--- a/src/en/guide/upgrading.adoc
+++ b/src/en/guide/upgrading.adoc
@@ -189,7 +189,23 @@ bootJar.enabled = false
 
 Grails 3 apps by default used http://gradle.org[Gradle] 3.5. Grails 4 apps use Gradle 5.
 
-To upgrade to Gradle 5 execute: 
+To upgrade to Gradle 5, first do it in `gradle.properties`
+
+[source, groovy]
+.build.gradle | Grails 3
+----
+gradleWrapperVersion=3.5
+----
+
+replace it with:
+
+[source, groovy]
+.build.gradle | Grails 4
+----
+gradleWrapperVersion=5.0
+----
+
+Then execute: 
 
 [source, bash]
 ----


### PR DESCRIPTION
Must Set gradle.properties before calling ./gradlew

...or else:
> Failed to apply plugin [class 'org.springframework.boot.gradle.plugin.SpringBootPlugin']
   > Spring Boot plugin requires Gradle 4.4 or later. The current version is Gradle 3.5