### PR TITLE
Update Gradle Samples

### DIFF
--- a/src/en/guide/profiles/profileInheritance.adoc
+++ b/src/en/guide/profiles/profileInheritance.adoc
@@ -3,7 +3,7 @@ One profile can extend one or many different parent profiles. To define profile 
 [source,groovy]
 ----
 dependencies {
-    runtime project(':base')
+    runtime "org.grails.profiles:base:$baseProfileVersion"
 }
 ----
 
@@ -20,8 +20,8 @@ To define the order of inheritance ensure that your dependencies are declared in
 [source,groovy]
 ----
 dependencies {
-    runtime project(':plugin')
-    runtime project(':web')
+    runtime "org.grails.profiles:plugin:$baseProfileVersion"
+    runtime "org.grails.profiles:web:$baseProfileVersion"
 }
 ----
 


### PR DESCRIPTION
Custom plugins generally won't be built as part of a multiproject build along with `base`, `plugin` and `web`.