### PR TITLE
Remove obsolete JVM parameter

### DIFF
--- a/src/en/guide/gettingStarted/deployingAnApplication.adoc
+++ b/src/en/guide/gettingStarted/deployingAnApplication.adoc
@@ -43,5 +43,5 @@ When deploying Grails you should always run your containers JVM with the `-serve
 
 [source,bash]
 ----
--server -Xmx768M -XX:MaxPermSize=256m
+-server -Xmx768M
 ----


### PR DESCRIPTION
Since Grails 4 requires a JDK 8 as per https://docs.grails.org/4.0.0/guide/single.html#requirements the PermGen space-related `XX:MaxPermSize` is obsolete.