### PR TITLE
Update gradleDependencies.adoc

### DIFF
--- a/src/en/guide/commandLine/gradleBuild/gradleDependencies.adoc
+++ b/src/en/guide/commandLine/gradleBuild/gradleDependencies.adoc
@@ -19,7 +19,8 @@ dependencies {
   runtime 'org.grails.plugins:asset-pipeline'
   runtime 'org.grails.plugins:scaffolding'
 
-  testCompile 'org.grails:grails-plugin-testing'
+  testCompile "org.grails:grails-gorm-testing-support"
+  testCompile "org.grails:grails-web-testing-support"
   testCompile 'org.grails.plugins:geb'
 
   // Note: It is recommended to update to a more robust driver (Chrome, Firefox etc.)


### PR DESCRIPTION
according to this https://github.com/grails/grails-core/issues/11293 `org.grails:grails-plugin-testing` is deprecated and although this document is an example can be confuse