### PR TITLE
Updated reference to Grails 3.1

### DIFF
--- a/src/en/guide/commandLine/gradleBuild.adoc
+++ b/src/en/guide/commandLine/gradleBuild.adoc
@@ -1,4 +1,4 @@
-Grails 3.1 uses the http://gradle.org[Gradle Build System] for build related tasks such as compilation, runnings tests and producing binary distributions of your project. It is recommended to use Gradle 2.2 or above with Grails 3.1.
+Since Grails 3.1 the http://gradle.org[Gradle Build System] is used for build related tasks such as compilation, runnings tests and producing binary distributions of your project. It is recommended to use Gradle 2.2 or above with Grails 3.1 (and higher).
 
 The build is defined by the `build.gradle` file which specifies the version of your project, the dependencies of the project and the repositories where to find those dependencies (amongst other things).
 
@@ -10,7 +10,7 @@ When you invoke the `grails` command the version of Gradle that ships with Grail
 $ grails compile
 ----
 
-You can invoke Gradle directly using the `gradle` command and use your own local version of Gradle, however you will need Gradle 2.2 or above to work with Grails 3.0:
+You can invoke Gradle directly using the `gradle` command and use your own local version of Gradle, however you will need Gradle 2.2 or above to work with Grails 3.0 (and higher):
 
 [source,bash]
 ----


### PR DESCRIPTION
Updated reference to Grails 3.1 to Grails 3.1 (and higher).