### PR TITLE
Update upgrading33x.adoc

### DIFF
--- a/src/en/guide/upgrading/upgrading33x.adoc
+++ b/src/en/guide/upgrading/upgrading33x.adoc
@@ -18,7 +18,7 @@ Grails 4 app's `gradle.properties`
 .gradle.properties
 ----
 ...
-grailsVersion=4.0.3
+grailsVersion=4.0.4
 ...
 ----
 
@@ -42,7 +42,7 @@ Grails 4 app's `gradle.properties`
 .gradle.properties
 ----
 ...
-gormVersion=7.0.2
+gormVersion=7.0.4
 ...
 ----
 
@@ -210,7 +210,7 @@ To upgrade to Gradle 5 execute:
 Due to changes in Gradle 5, https://docs.gradle.org/current/userguide/upgrading_version_4.html#rel5.0:pom_compile_runtime_separation[transitive dependencies are no longer resolved] for plugins. If your project makes use of a plugin that has transitive dependencies, you will need to add those explicitly to your `build.gradle` file.
 
 If you customized your app's build, other migrations may be necessary. Please check
-https://docs.gradle.org/current/userguide/upgrading_version_4.html[Gradle Upgrading your build] documentation.
+https://docs.gradle.org/current/userguide/upgrading_version_4.html[Gradle Upgrading your build] documentation. Especially notice, that default Gradle daemon now starts with 512MB of heap instead of 1GB. Please check https://docs.gradle.org/current/userguide/upgrading_version_4.html#rel5.0:default_memory_settings[Default memory settings changed] documentation.
 
 ### H2 Web Console
 


### PR DESCRIPTION
Minor version bumps. Add specific notice, that gradle memory management changed with the latest version, which leads to memory issues for large-size projects.