### PR TITLE
Update upgrading40x.adoc

### DIFF
--- a/src/en/guide/upgrading/upgrading40x.adoc
+++ b/src/en/guide/upgrading/upgrading40x.adoc
@@ -54,7 +54,7 @@ NOTE: Enabling StringCharArrayAccessor would show IllegalReflectiveAccess warnin
 
 ### Changes in profile.yml and feature.yml files in Grails Profiles
 
-The format of how dependencies are defined in features and profiles has been changed. See the section on link:{guidePath}/profiles.html[Application Profiles] for more information.
+The format of how dependencies are defined in features and profiles has been changed. See the section on link:profiles.html[Application Profiles] for more information.
 
 ### Deprecation of dot navigation of Grails configuration
 


### PR DESCRIPTION
Broken link for link:{guidePath}/profiles.html[Application Profiles] in section Changes in profile.yml and feature.yml files in Grails Profiles. 
Presume it should point to the section on Profiles in this guide,  
link:profiles.html[Application Profiles]