### PR TITLE
Update upgrading32x.adoc

### DIFF
--- a/src/en/guide/upgrading/upgrading32x.adoc
+++ b/src/en/guide/upgrading/upgrading32x.adoc
@@ -10,7 +10,7 @@ If your codebase uses the legacy converters it is encouraged to convert the func
 
 .build.gradle
 ----
-    compile "org.grails.plugins:grails-plugin-converters"
+    compile "org.grails.plugins:converters"
 ----
 
 WARNING: The support to build JSON directly from the render method no longer supports the old API and any code that used it will need to be converted to use the {groovyapi}groovy/json/StreamingJsonBuilder.html[groovy.json.StreamingJsonBuilder] syntax.


### PR DESCRIPTION
Only version 3.3.0.BUILD-SNAPSHOT exist with artifact id grails-plugin-converters (https://repo.grails.org/grails/core/org/grails/plugins/grails-plugin-converters/). 3.3.0.RC1 and later has been renamed to converters (https://repo.grails.org/grails/core/org/grails/plugins/converters/)