### PR TITLE
Update cors.adoc

### DIFF
--- a/src/en/guide/theWebLayer/cors.adoc
+++ b/src/en/guide/theWebLayer/cors.adoc
@@ -80,5 +80,5 @@ grails:
     cors:
         enabled: true
         mappings:
-            /api/**: inherit
+            '[/api/**]': inherit
 ----


### PR DESCRIPTION
Use bracket notation for mappings. Breaking change in Spring Boot 2 / Grails 4.
Was fixed in the example above in commit 4ef94df227e0783a382fea3e1eb972160d2a14a4, but this example also needs the same change.
See also https://github.com/grails/grails-core/issues/11639