### PR TITLE
Update cors.adoc

### DIFF
--- a/src/en/guide/theWebLayer/cors.adoc
+++ b/src/en/guide/theWebLayer/cors.adoc
@@ -19,7 +19,7 @@ That will produce a mapping to all urls `/**` with:
 |allowedHeaders |`['*']`
 |exposedHeaders |`null`
 |maxAge         |`1800`
-|allowCredentials |true
+|allowCredentials |false
 |=======
 
 Some of these settings come directly from Spring Boot and can change in future versions. See {springapi}/org/springframework/web/cors/CorsConfiguration.html#applyPermitDefaultValues[Spring CORS Configuration Documentation]
@@ -68,7 +68,7 @@ The settings above will produce a single mapping of `/api/**` with the following
 |allowedHeaders |`['Content-Type']`
 |exposedHeaders |`null`
 |maxAge         |`1800`
-|allowCredentials |true
+|allowCredentials |false
 |=======
 
 If you don't wish to override any of the default settings, but only want to specify URLs, you can do so like this example:


### PR DESCRIPTION
allowCredentials changed default from true to false in Spring 4.3.24.RELEASE.

https://docs.spring.io/spring-framework/docs/4.3.23.RELEASE/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#applyPermitDefaultValues--
https://docs.spring.io/spring-framework/docs/4.3.24.RELEASE/javadoc-api/org/springframework/web/cors/CorsConfiguration.html#applyPermitDefaultValues--