### PR TITLE
Clarify maxSize usage

### DIFF
--- a/src/en/ref/Constraints/maxSize.adoc
+++ b/src/en/ref/Constraints/maxSize.adoc
@@ -21,6 +21,8 @@ children maxSize: 25
 === Description
 
 
+Sets the maximum size of a collection or number property.
+
 This constraint influences http://gorm.grails.org/6.0.x/hibernate/manual/index.html#constraints[schema generation].
 
 Error Code: `className.propertyName.maxSize.exceeded`


### PR DESCRIPTION
`minSize` clearly states that it can be used for collections, but `maxSize` does not mention anything specifically.

Updated to aid in clarity