### PR TITLE
Use version placeholder in dependencyUpgrades.adoc (4.0.x branch)

### DIFF
--- a/src/en/guide/introduction/whatsNew/dependencyUpgrades.adoc
+++ b/src/en/guide/introduction/whatsNew/dependencyUpgrades.adoc
@@ -1,9 +1,9 @@
-Grails 4.0.7 ships with the following dependency upgrades:
+Grails {version} ships with the following dependency upgrades:
 
 * Groovy 2.5.14
 * GORM 7 and Hibernate 5.4 (now the default version of Hibernate for new applications)
 * Spring Framework 5.1.20
 * Spring Boot 2.1.18
-* Gradle 5.1.1
+* Gradle 5.6.4
 * Spock 1.3
 


### PR DESCRIPTION
- Grails version was not updated since 4.0.7.