### PR TITLE
Update email.adoc to reflect new email validator

### DIFF
--- a/src/en/ref/Constraints/email.adoc
+++ b/src/en/ref/Constraints/email.adoc
@@ -21,6 +21,8 @@ homeEmail email: true
 === Description
 
 
-Set to `true` if a string value must be an email address. Internally uses the `org.apache.commons.validator.EmailValidator` class.
+Set to `true` if a string value must be an email address. 
+
+Internally uses the `org.apache.commons.validator.routines.EmailValidator` class (i.e. in contrast to earlier Grails versions no longer the deprecated `org.apache.commons.validator.EmailValidator` with the most notable difference that the new version validates the emails TLDs).
 
 Error Code: `className.propertyName.email.invalid`


### PR DESCRIPTION
We encountered this new behavior today in a system that was upgraded from Grails 3.2.3 to Grails 4.0.12.

Relevant Code:


```
package org.grails.datastore.gorm.validation.constraints;

import grails.gorm.validation.ConstrainedProperty;
import org.apache.commons.validator.routines.EmailValidator;
import org.springframework.context.MessageSource;
import org.springframework.util.StringUtils;
import org.springframework.validation.Errors;

/**
 * Validates an email address.
 *
 * @author Graeme Rocher
 * @since 0.4
 */
public class EmailConstraint extends AbstractConstraint {
```