### PR TITLE
Information about to Gradle 7 upgrade required changes

### DIFF
--- a/src/en/guide/plugins/creatingAndInstallingPlugins.adoc
+++ b/src/en/guide/plugins/creatingAndInstallingPlugins.adoc
@@ -149,7 +149,7 @@ repositories {
     mavenLocal()
 }
 ...
-compile "org.grails.plugins:quartz:0.1"
+implementation "org.grails.plugins:quartz:0.1"
 ----
 
 NOTE: In Grails 2.x plugins were packaged as ZIP files, however in Grails 3.x plugins are simple JAR files that can be added to the classpath of the IDE.
@@ -200,7 +200,7 @@ Within the `build.gradle` of the application declare a dependency on the plugin 
 ----
 grails {
     plugins {
-        compile project(':myplugin')
+        implementation project(':myplugin')
     }
 }
 ----
@@ -309,7 +309,7 @@ Finally add a dependency in your application's `build.gradle` on the plugin:
 
 [source,groovy]
 ----
-compile project(':myplugin')
+implementation project(':myplugin')
 ----
 
 Using this technique you have achieved the equivalent of inline plugins from Grails 2.x.

--- a/src/en/guide/upgrading/upgrading40x.adoc
+++ b/src/en/guide/upgrading/upgrading40x.adoc
@@ -90,3 +90,30 @@ Grails 5.1.1 is shipped with Micronaut 3.2.0. Please check the https://docs.micr
 ### Micronaut for Spring 4.0.1
 
 Grails 5.1.1 is updated to Micronaut for Spring 4.0.1, please check out https://github.com/micronaut-projects/micronaut-spring/releases/tag/v4.0.1[release notes] for more information.
+
+### Gradle 7.x
+
+#### Compile dependency configuration as well as others have been removed from Gradle 7.x. In previous version they were deprecated.
+
+Replace configurations:
+[source, properties]
+.build.gradle
+----
+...
+ compile -> implementation
+ testCompile -> testImplementation
+ runtime -> runtimeOnly
+...
+----
+
+NOTE: More information in Gradle upgrade docs https://docs.gradle.org/current/userguide/upgrading_version_6.html#sec:configuration_removal[Gradle upgrade docs]
+
+#### Plugins in multi-project setup
+
+If you have grails plugins as part of multi-project builds you should also replace the `compile` with `implementation` configuration.
+
+Additionally if your main application relied on the dependencies declared by the plugin you need to apply further changes.
+
+To make the dependencies available again you have to declare them with `api` configuration. You also have to apply the `java-library` gradle plugin in your plugin project.
+
+NOTE: More information https://docs.gradle.org/current/userguide/java_library_plugin.html[gradle java-library-plugin]


### PR DESCRIPTION
relates to https://github.com/grails/grails-core/issues/12367

* upgrade section guide related to full removal of compile configuration name in Gradle 7 as well as the impact on grails plugins in multi-project builds
*  updates to snippets where `implementation` configuration needs to be used as compile is not available any more