### PR TITLE
Update the documentation about spring-boot-starter-tomcat

### DIFF
--- a/src/en/guide/gettingStarted/deployingAnApplication.adoc
+++ b/src/en/guide/gettingStarted/deployingAnApplication.adoc
@@ -9,11 +9,11 @@ grails war
 
 This will produce a WAR file under the `build/libs` directory which can then be deployed as per your container's instructions.
 
-Note that by default Grails will include an embeddable version of Tomcat inside the WAR file, this can cause problems if you deploy to a different version of Tomcat. If you don't intend to use the embedded container then you should change the scope of the Tomcat dependencies to `provided` prior to deploying to your production container in `build.gradle`:
+Note that by default Grails will include an embeddable version of Tomcat inside the WAR file, this can cause problems if you deploy to a different version of Tomcat. If you don't intend to use the embedded container then you should change the scope of the Tomcat dependencies to `testImplementation` (or `provided` if using Grails 4.x) prior to deploying to your production container in `build.gradle`:
 
 [source,groovy]
 ----
-provided "org.springframework.boot:spring-boot-starter-tomcat"
+testImplementation "org.springframework.boot:spring-boot-starter-tomcat"
 ----
 
 If you are building a WAR file to deploy on Tomcat 7 then in addition you will need to change the target Tomcat version in the build. Grails is built against Tomcat 8 APIs by default.


### PR DESCRIPTION
Update the getting started documentation about `spring-boot-starter-tomcat` so it is current for Grails 5 and consistent with this guide:

https://github.com/grails/grails-doc/blob/0d2248cea237ef5281edc26f2e5322750dc9608e/src/en/guide/deployment/deploymentContainer.adoc