### PR TITLE
update logging.adoc for logback>=1.2.9

### DIFF
--- a/src/en/guide/conf/config/logging.adoc
+++ b/src/en/guide/conf/config/logging.adoc
@@ -1,5 +1,3 @@
-Since Grails 3.0, logging is handled by the http://logback.qos.ch[Logback logging framework] and can be configured with the `grails-app/conf/logback.groovy` file.
-
-NOTE: If you prefer XML you can replace the `logback.groovy` file with a `logback.xml` file instead.
+Since Grails 5.1.2, logging is handled by the http://logback.qos.ch[Logback logging framework] and can be configured with the `grails-app/conf/logback.xml` file.
 
 For more information on configuring logging refer to the http://logback.qos.ch/manual/groovy.html[Logback documentation] on the subject.


### PR DESCRIPTION
the logback.groovy file can't be used anymore (:-()