### PR TITLE
Update doc in order to specify an upper JDK limit.

### DIFF
--- a/src/en/guide/gettingStarted/requirements.adoc
+++ b/src/en/guide/gettingStarted/requirements.adoc
@@ -1,4 +1,4 @@
-Before installing Grails {version} you will need as a minimum a Java Development Kit (JDK) installed version 1.8 or above. Download the appropriate JDK for your operating system, run the installer, and then set up an environment variable called `JAVA_HOME` pointing to the location of this installation.
+Before installing Grails {version} you will need as a minimum a Java Development Kit (JDK) installed version 1.8. The most recent supported version of the JDK is 11. Download the appropriate JDK for your operating system, run the installer, and then set up an environment variable called `JAVA_HOME` pointing to the location of this installation.
 
 To automate the installation of Grails we recommend http://sdkman.io[SDKMAN] which greatly simplifies installing and managing multiple Grails versions.
 


### PR DESCRIPTION
Addresses issue #772 to aid those new to Grails to get going with the correct SDK.