### PR TITLE
Remove logback.groovy from documentation

### DIFF
--- a/src/en/guide/conf/config/logging.adoc
+++ b/src/en/guide/conf/config/logging.adoc
@@ -1,5 +1,3 @@
-Since Grails 3.0, logging is handled by the http://logback.qos.ch[Logback logging framework] and can be configured with the `grails-app/conf/logback.groovy` file.
+Since Grails 3.0, logging is handled by the http://logback.qos.ch[Logback logging framework] and can be configured with the `grails-app/conf/logback.xml` file.
 
-NOTE: If you prefer XML you can replace the `logback.groovy` file with a `logback.xml` file instead.
-
-For more information on configuring logging refer to the http://logback.qos.ch/manual/groovy.html[Logback documentation] on the subject.
+For more information on configuring logging refer to the https://logback.qos.ch/manual/configuration.html[Logback documentation] on the subject.

--- a/src/en/guide/conf/config/logging/externalLoggingConfiguration.adoc
+++ b/src/en/guide/conf/config/logging/externalLoggingConfiguration.adoc
@@ -4,18 +4,18 @@ If you set the configuration property `logging.config`, you can instruct `Logbac
 .grails-app/conf/application.yml
 ----
 logging:
-    config: /Users/me/config/logback.groovy
+    config: /Users/me/config/logback.xml
 ----
 
 Alternatively, you can supply the configuration file location with a system property:
 
-`$ ./gradlew -Dlogging.config=/Users/me/config/logback.groovy bootRun`
+`$ ./gradlew -Dlogging.config=/Users/me/config/logback.xml bootRun`
 
 Or, you could use an environment variable:
 
 [source, bash]
 ----
-$ export LOGGING_CONFIG=/Users/me/config/logback.groovy
+$ export LOGGING_CONFIG=/Users/me/config/logback.xml
 $ ./gradlew bootRun
 ----
 

--- a/src/en/guide/upgrading/upgrading40x.adoc
+++ b/src/en/guide/upgrading/upgrading40x.adoc
@@ -90,3 +90,7 @@ Grails 5.0.0.RC1 is shipped with Micronaut 2.0. Please check the https://docs.mi
 ### Micronaut for Spring 3.0.0
 
 Grails 5.0.0.RC1 is updated to Micronaut for Spring 3.0.0, please check out https://github.com/micronaut-projects/micronaut-spring/releases/tag/v3.0.0[release notes] for more information.
+
+### Convert logback.groovy to logback.xml
+
+Support for logback.groovy was removed in logback 2.9.0 to mitigate https://cve.report/CVE-2021-42550[CVE-2021-42550]. See the https://jira.qos.ch/browse/LOGBACK-1591[upstream issue] for more information. 


### PR DESCRIPTION
Remove documentation of logback.groovy from the logging section.

According to https://logback.qos.ch/news.html logback.groovy support was removed to mitigate [CVE-2021-42550](https://cve.report/CVE-2021-42550). See also https://jira.qos.ch/browse/LOGBACK-1591.