### PR TITLE
Cleans up testing documentation which states that the test mixin framework is still usable

### DIFF
--- a/src/en/guide/testing/unitTesting.adoc
+++ b/src/en/guide/testing/unitTesting.adoc
@@ -23,12 +23,4 @@ class HelloControllerTests extends Specification implements ControllerUnitTest<H
 For more information on writing tests with Grails Testing Support see the https://testing.grails.org[dedicated documentation].
 
 
-Versions of Grails below 3.2 used the https://grails-plugins.github.io/grails-test-mixin-plugin/latest/guide/index.html[Grails Test Mixin Framework] which was based on the `@TestMixin` AST transformation. This library has been superceded by the simpler and more IDE friendly trait based implementation. However you can still use it by adding the following dependency to your Grails application:
-
-.build.gradle
-[source,groovy]
-----
-testCompile "org.grails:grails-test-mixins:3.3.0"
-----
-
-This may be useful if you are, for example, upgrading an existing application to Grails 3.3.x.
+Versions of Grails below 3.2 used the https://grails-plugins.github.io/grails-test-mixin-plugin/latest/guide/index.html[Grails Test Mixin Framework] which was based on the `@TestMixin` AST transformation. This library has been superceded by the simpler and more IDE friendly trait based implementation.


### PR DESCRIPTION
Cleans up testing documentation which states that the test mixin framework is still usable