### PR TITLE
Update supportedJavaEEContainers.adoc

### DIFF
--- a/src/en/guide/gettingStarted/supportedJavaEEContainers.adoc
+++ b/src/en/guide/gettingStarted/supportedJavaEEContainers.adoc
@@ -1,6 +1,6 @@
 Grails runs on any container that supports Servlet 3.0 and above and is known to work on the following specific container products:
 
-* Tomcat 7
+* Tomcat 7 (end of life) 
 * GlassFish 3 or above
 * Resin 4 or above
 * JBoss 6 or above


### PR DESCRIPTION
I do run Grails applications in Tomcat 9  environment. Can these be added? Verification should be done by the Grails team???