### PR TITLE
Update Action TagAndRelease

### DIFF
--- a/.github/actions/tag-and-release/entrypoint.sh
+++ b/.github/actions/tag-and-release/entrypoint.sh
@@ -27,8 +27,8 @@ cat gradle.properties
 
 echo "Pushing release version and recreating v${grails_version} tag"
 git add gradle.properties
-git commit -m "Release v${grails_version} docs"
+git commit -m "[skip ci] Release v${grails_version} docs"
 git push origin $TARGET_BRANCH
 git push origin :refs/tags/v${grails_version}
-git tag -fa v${grails_version} -m "Release v${grails_version} docs"
+git tag -fa v${grails_version} -m "[skip ci] Release v${grails_version} docs"
 git push origin $TARGET_BRANCH --tags


### PR DESCRIPTION
Append "[skip ci]" to commit message to skip trigger Java CI workflow for release commit.