### PR TITLE
Update the Gradle dependency of "spring-boot-starter-tomcat" for container deployment

### DIFF
--- a/src/en/guide/deployment/deploymentContainer.adoc
+++ b/src/en/guide/deployment/deploymentContainer.adoc
@@ -19,7 +19,7 @@ Note that by default Grails will include an embeddable version of Tomcat inside 
 
 [source,groovy]
 ----
-testImplementation "org.springframework.boot:spring-boot-starter-tomcat"
+runtimeOnly "org.springframework.boot:spring-boot-starter-tomcat"
 ----
 
 


### PR DESCRIPTION
The documentation at https://docs.grails.org/5.2.5/guide/deployment.html#deploymentContainer says that we should change the dependency of `org.springframework.boot:spring-boot-starter-tomcat` from `implementation` to `testImplementation` but this will break the `grails run-app` or `./gradlew bootRun`.

If I change to `testImplementation` on a brand new Grails 5.2.3 app created with `grails create-app test-grails --features mongodb --profile=rest-api`, the application fails:

```
> Task :bootRun
2022-12-27 15:55:20.649 ERROR --- [  restartedMain] o.s.b.d.LoggingFailureAnalysisReporter   : 

***************************
APPLICATION FAILED TO START
***************************

Description:

Web application could not be started as there was no org.springframework.boot.web.servlet.server.ServletWebServerFactory bean defined in the context.

Action:

Check your application's dependencies for a supported servlet web server.
Check the configured web application type.
```

The correct fix should have been `runtimeOnly` (my best guess) because earlier (for Grails 4.x), it was `provided`.

(I'm intentionally not creating an issue at `grails/grails-core` to avoid noise)

