### PR TITLE
Clarify the overview in the What's new section.

### DIFF
--- a/src/en/guide/introduction/whatsNew.adoc
+++ b/src/en/guide/introduction/whatsNew.adoc
@@ -2,9 +2,8 @@ This section covers all the new features introduced in Grails 6
 
 === Overview
 
-Grails framework 6 updates to Spring 5.3.27 and Spring Boot 2.7.12. We recommend checking the following Spring technologies release notes for more information.
+Grails framework 6 updates Spring Boot to version 2.7. We recommend checking the following Spring technologies release notes for more information.
 
 * https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes[Spring Boot 2.7]
-* https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-5.x#upgrading-to-version-53[Upgrading to Spring Framework 5.3]
 
-Grails framework 6 is built with Groovy 3.0.11, which requires JDK 11 as the minimum version of JRE.
+The minimum Java version required to run Grails 6 has been updated to Java 11.


### PR DESCRIPTION
This version of the text:
- Removes the mention of Spring Framework 5.3 and Groovy 3, as these were already the versions used in Grails 5.
- Does not show the patch release version of Spring Boot 2.7.12, as this is not relevant to the overall message.
- Corrects the misconception that Groovy 3 requires Java 11.
