### PR TITLE
Update params.adoc

### DIFF
--- a/src/en/ref/Controllers/params.adoc
+++ b/src/en/ref/Controllers/params.adoc
@@ -6,7 +6,8 @@
 === Purpose
 
 
-A mutable multi-dimensional map (hash) of request (CGI) parameters.
+A mutable multi-dimensional map (hash) of request (CGI) parameters. 
+See link:https://docs.grails.org/latest/api/grails/web/servlet/mvc/GrailsParameterMap.html[api documentation] for details.
 
 
 === Examples


### PR DESCRIPTION
params are of type GrailsParameterMap and have some features that are not included in this part but should be mentioned.