### PR TITLE
fix dependencies in whatsNew.adoc

### DIFF
--- a/src/en/guide/introduction/whatsNew.adoc
+++ b/src/en/guide/introduction/whatsNew.adoc
@@ -5,7 +5,7 @@ This release includes support for Apache Groovy 3, Micronaut framework 3, Gradle
 
 Apache Groovy 3 is a major highlight of this release. It comes with a brand new Parrot parser and a bunch of new features and capabilities. The Parrot parser supports additional syntax and language features, such as lambda expressions, default methods with interfaces, and a lot more. In addition, several new extension methods are added to existing Java classes. See the https://groovy-lang.org/releasenotes/groovy-3.0.html#releasenotes[release notes for Groovy 3.0] for details.
 
-Grails framework 5 updates to Spring 5.3.10 and Spring Boot 2.7.0. We strongly recommend checking the following Spring technologies release notes for more information.
+Grails framework 5 updates to Spring 5.3.10 and Spring Boot 2.7.8. We strongly recommend checking the following Spring technologies release notes for more information.
 
 * https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes[Spring Boot 2.7]
 * https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-5.x#upgrading-to-version-53[Upgrading to Spring Framework 5.3]

--- a/src/en/guide/introduction/whatsNew.adoc
+++ b/src/en/guide/introduction/whatsNew.adoc
@@ -1,16 +1,16 @@
 This section covers all the new features introduced in Grails 5
 
 === Overview
-This release includes support for Apache Groovy 3, Micronaut framework 3, Gradle 7, Spring Boot 2.6, Spring framework 5.3, and Spock 2.0.
+This release includes support for Apache Groovy 3, Micronaut framework 3, Gradle 7, Spring Boot 2.7, Spring framework 5.3, and Spock 2.0.
 
 Apache Groovy 3 is a major highlight of this release. It comes with a brand new Parrot parser and a bunch of new features and capabilities. The Parrot parser supports additional syntax and language features, such as lambda expressions, default methods with interfaces, and a lot more. In addition, several new extension methods are added to existing Java classes. See the https://groovy-lang.org/releasenotes/groovy-3.0.html#releasenotes[release notes for Groovy 3.0] for details.
 
-Grails framework 5 updates to Spring 5.3.10 and Spring Boot 2.5.5. We strongly recommend checking the following Spring technologies release notes for more information.
+Grails framework 5 updates to Spring 5.3.10 and Spring Boot 2.7.0. We strongly recommend checking the following Spring technologies release notes for more information.
 
-* https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.6-Release-Notes[Spring Boot 2.6]
+* https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.7-Release-Notes[Spring Boot 2.7]
 * https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-5.x#upgrading-to-version-53[Upgrading to Spring Framework 5.3]
 
-Grails framework 5 is built with Groovy 3.0.7, which requires JDK 8 as the minimum version of JRE. We have tested most Grails projects up to JDK 14.
+Grails framework 5 is built with Groovy 3.0.11, which requires JDK 8 as the minimum version of JRE. We have tested most Grails projects up to JDK 14.
 
 === Important Changes
 


### PR DESCRIPTION
after installing grails 5.3.3 and run ./gradlew dependencies the out put is: org.springframework.boot:spring-boot:2.7.9 -> 2.7.8 , org.codehaus.groovy:groovy:3.0.11 