### PR TITLE
fix(ci): Update snapshot publishing

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -48,7 +48,7 @@ jobs:
           if_true: 'grails/grails-doc'
           if_false: ${{ github.repository }}
       - name: Publish Snapshot Documentation to Github Pages
-        if: success() && github.event_name == 'push' && github.ref == 'refs/heads/6.0.x'
+        if: success() && github.event_name == 'push'
         uses: micronaut-projects/github-pages-deploy-action@grails
         env:
           BRANCH: gh-pages
@@ -57,4 +57,8 @@ jobs:
           FOLDER: build/docs
           GH_TOKEN: ${{ secrets.GH_TOKEN }}
           TARGET_REPOSITORY: ${{ steps.docs_target.outputs.value }}
-          SKIP_SNAPSHOT: ${{ startsWith(steps.extract_branch.outputs.value, '3.3') || startsWith(steps.extract_branch.outputs.value, '4.1') || startsWith(steps.extract_branch.outputs.value, '5.3') }}
+          SKIP_SNAPSHOT: ${{
+              startsWith(steps.extract_branch.outputs.value, '3.3') ||
+              startsWith(steps.extract_branch.outputs.value, '4.1') ||
+              startsWith(steps.extract_branch.outputs.value, '5.3')
+            }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,13 @@ jobs:
     runs-on: ubuntu-latest
     env:
       BETA: ${{ contains(github.event.inputs.grails_version, 'M') }}
-      SKIP_SNAPSHOT: ${{ startsWith(github.event.inputs.grails_version, '3.3') || startsWith(github.event.inputs.grails_version, '4.1') || startsWith(github.event.inputs.grails_version, '5.3') || contains(github.event.inputs.grails_version, 'M') || contains(github.event.inputs.grails_version, 'RC') }}
+      SKIP_SNAPSHOT: ${{
+          startsWith(github.event.inputs.grails_version, '3.3') ||
+          startsWith(github.event.inputs.grails_version, '4.1') ||
+          startsWith(github.event.inputs.grails_version, '5.3') ||
+          contains(github.event.inputs.grails_version, 'M') ||
+          contains(github.event.inputs.grails_version, 'RC')
+        }}
       GIT_USER_NAME: puneetbehl
       GIT_USER_EMAIL: behlp@unityfoundation.io
     steps:


### PR DESCRIPTION
Snapshots for the active branch were not published because of a condition in the github workflow.

The SKIP_SNAPSHOT env var should suffice to prevent snapshot publishing of older branches.

Also formatted the SKIP_SNAPSHOT conditions, so it is easier to read and maintain, especially when more branches are added.