### PR TITLE
docs: Update Grails BOM.adoc

### DIFF
--- a/src/en/ref/Dependency Versions/Grails BOM.adoc
+++ b/src/en/ref/Dependency Versions/Grails BOM.adoc
@@ -35,7 +35,7 @@ This document provides information about the dependencies mentioned in the Grail
 | {io_micronaut_spring_micronaut_spring_spring_version}
 
 | org.mongodb
-| mongodb-driver-core, mongodb-driver-sync
+| mongodb-driver-core, mongodb-driver-sync, bson, bson-record-codec
 | {org_mongodb_mongodb_driver_core_version}
 
 | org.grails


### PR DESCRIPTION
Add `org.mongodb:bson` and `org.mongodb:bson-record-codec` to the BOM details page.