### PR TITLE
fix(docs): Sort BOM entries

### DIFF
--- a/src/en/ref/Dependency Versions/Grails BOM.adoc
+++ b/src/en/ref/Dependency Versions/Grails BOM.adoc
@@ -6,20 +6,20 @@ This document provides information about the dependencies mentioned in the Grail
 |===
 | Group ID | Artifact ID | Version
 
+| com.h2database
+| h2
+| {com_h2database_h2_version}
+
 | io.github.gpc
 | fields
 | {io_github_gpc_fields_version}
 
-| javax.annotation
-| javax.annotation-api
-| {javax_annotation_javax_annotation_api_version}
-
-| jakarta.annotation
-| jakarta.annotation-api
-| {jakarta_annotation_jakarta_annotation_api_version}
+| io.methvin
+| directory-watcher
+| {io_methvin_directory_watcher_version}
 
 | io.micronaut
-| micronaut-aop, micronaut-bom, micronaut-inject, micronaut-runtime, micronaut-inject-groovy, micronaut-inject-java, micronaut-core, micronaut-http-client, micronaut-http, micronaut-buffer-netty, micronaut-http-netty
+| micronaut-aop, micronaut-bom, micronaut-buffer-netty, micronaut-core, micronaut-http, micronaut-http-client, micronaut-http-netty, micronaut-inject, micronaut-inject-groovy, micronaut-inject-java, micronaut-runtime
 | {io_micronaut_micronaut_core_version}
 
 | io.micronaut.cache
@@ -31,71 +31,71 @@ This document provides information about the dependencies mentioned in the Grail
 | {io_micronaut_groovy_micronaut_runtime_groovy_version}
 
 | io.micronaut.spring
-| micronaut-spring, micronaut-spring-context, micronaut-spring-boot, micronaut-spring-web, micronaut-spring-boot-annotation, micronaut-spring-annotation, micronaut-spring-web-annotation
+| micronaut-spring, micronaut-spring-annotation, micronaut-spring-boot, micronaut-spring-boot-annotation, micronaut-spring-context, micronaut-spring-web, micronaut-spring-web-annotation
 | {io_micronaut_spring_micronaut_spring_spring_version}
 
-| org.mongodb
-| mongodb-driver-core, mongodb-driver-sync, bson, bson-record-codec
-| {org_mongodb_mongodb_driver_core_version}
+| jakarta.annotation
+| jakarta.annotation-api
+| {jakarta_annotation_jakarta_annotation_api_version}
+
+| javax.annotation
+| javax.annotation-api
+| {javax_annotation_javax_annotation_api_version}
+
+| org.codehaus.groovy
+| groovy, groovy-ant, groovy-console, groovy-dateutil, groovy-json, groovy-macro, groovy-nio, groovy-sql, groovy-swing, groovy-templates, groovy-xml
+| {org_codehaus_groovy_groovy_version}
 
 | org.grails
-| grails-datastore-async, grails-datastore-core, grails-datastore-web, grails-datastore-gorm, grails-datastore-gorm-async, grails-datastore-gorm-support, grails-datastore-gorm-rx, grails-datastore-gorm-test, grails-datastore-gorm-validation
+| grails-async-gpars, grails-events-gpars, grails-async-rxjava, grails-events-rxjava, grails-async-rxjava2, grails-events-rxjava2
+| {org_grails_grails_async_gpars_version}
+
+| org.grails
+| grails-datastore-async, grails-datastore-core, grails-datastore-gorm, grails-datastore-gorm-async, grails-datastore-gorm-support, grails-datastore-gorm-rx, grails-datastore-gorm-test, grails-datastore-gorm-validation, grails-datastore-web
 | {org_grails_grails_datastore_core_version}
 
 | org.grails
 | grails-datastore-gorm-hibernate5
 | {org_grails_grails_datastore_gorm_hibernate5_version}
 
-| org.codehaus.groovy
-| groovy, groovy-xml, groovy-swing, groovy-console, groovy-json, groovy-ant, groovy-sql, groovy-templates, groovy-nio, groovy-dateutil, groovy-macro
-| {org_codehaus_groovy_groovy_version}
+| org.grails
+| grails-gorm-testing-support, grails-testing-support, grails-web-testing-support
+| {org_grails_grails_testing_support_version}
 
 | org.grails
 | scaffolding-core
 | {org_grails_scaffolding_core_version}
 
-| org.springframework
-| spring-aop, spring-aspects, spring-beans, spring-context-support, spring-context, spring-core, spring-expression, spring-instrument, spring-jdbc, spring-jms, spring-messaging, spring-orm, spring-oxm, spring-test, spring-tx, spring-web, spring-webmvc, spring-websocket
-| {org_springframework_spring_core_version}
-
-| io.methvin
-| directory-watcher
-| {io_methvin_directory_watcher_version}
-
-| org.springframework
-| springloaded
-| {org_springframework_springloaded_version}
+| org.grails
+| views-json-testing-support
+| {org_grails_views_json_testing_support_version}
 
 | org.grails.plugins
 | async, events
 | {org_grails_plugins_async_version}
 
-| org.grails
-| grails-async-gpars, grails-events-gpars, grails-async-rxjava, grails-events-rxjava, grails-async-rxjava2, grails-events-rxjava2
-| {org_grails_grails_async_gpars_version}
+| org.grails.plugins
+| gsp
+| {org_grails_plugins_gsp_version}
 
-| org.yaml
-| snakeyaml
-| {org_yaml_snakeyaml_version}
+| org.mongodb
+| bson, bson-record-codec, mongodb-driver-core, mongodb-driver-sync
+| {org_mongodb_mongodb_driver_core_version}
+
+| org.springframework
+| spring-aop, spring-aspects, spring-beans, spring-context, spring-context-support, spring-core, spring-expression, spring-instrument, spring-jdbc, spring-jms, spring-messaging, spring-orm, spring-oxm, spring-test, spring-tx, spring-web, spring-webmvc
+| {org_springframework_spring_core_version}
+
+| org.springframework
+| springloaded
+| {org_springframework_springloaded_version}
 
 | org.spockframework
 | spock-core, spock-spring
 | {org_spockframework_spock_core_version}
 
-| org.grails.plugins
-| gsp
-| {org_grails_plugins_gsp_version}
-
-| org.grails
-| grails-testing-support, grails-gorm-testing-support, grails-web-testing-support
-| {org_grails_grails_testing_support_version}
-
-| org.grails
-| views-json-testing-support
-| {org_grails_views_json_testing_support_version}
-
-| com.h2database
-| h2
-| {com_h2database_h2_version}
+| org.yaml
+| snakeyaml
+| {org_yaml_snakeyaml_version}
 |===
 


### PR DESCRIPTION
For readability, this commit sorts the BOM table rows by groupId/artifactId and artifactId cells alphabetically.