### PR TITLE
Update creatingCustomCommands.adoc

### DIFF
--- a/src/en/guide/commandLine/creatingCustomCommands.adoc
+++ b/src/en/guide/commandLine/creatingCustomCommands.adoc
@@ -32,7 +32,7 @@ To create a custom command, you need to create a Groovy class that implements th
 // grails-app/commands/com/example/GreetCommand.groovy
 package com.example
 
-import grails.cli.GrailsApplicationCommand
+import grails.dev.commands.GrailsApplicationCommand
 
 class GreetCommand implements GrailsApplicationCommand {
 
@@ -91,7 +91,7 @@ Grails also supports command-line arguments and options for custom commands. You
 // grails-app/commands/com/example/GreetCommand.groovy
 package com.example
 
-import grails.cli.GrailsApplicationCommand
+import grails.dev.commands.GrailsApplicationCommand
 
 class GreetCommand implements GrailsApplicationCommand {
 
@@ -155,7 +155,7 @@ Here's an example of how you can create a custom command that uses the execution
 // grails-app/commands/com/example/BackupCommand.groovy
 package com.example
 
-import grails.cli.GrailsApplicationCommand
+import grails.dev.commands.GrailsApplicationCommand
 
 class BackupCommand implements GrailsApplicationCommand {
 


### PR DESCRIPTION
Class grails.cli.GrailsApplicationCommand does not exist. Based on other recently updated commands the correct class is grails.dev.commands.GrailsApplicationCommand

Tested and worked.

First ever PR here, I hope the process is lean.