### PR TITLE
fix(docs): Add `grails-web-fileupload` to breaking changes

### DIFF
--- a/src/en/guide/upgrading/upgrading60x.adoc
+++ b/src/en/guide/upgrading/upgrading60x.adoc
@@ -95,5 +95,6 @@ Grails 7 introduces several breaking changes that may require updates to your ap
 ##### 8.1. Inheritance in GORM
 With the update to Groovy 4, there is an issue with extending domain classes. A workaround is to *_not_* annotate parent classes with `@Entity` or put them in the `grails-app/domain` folder. Use `src/main/groovy` instead.
 
-#### 8.2. Removed classes
+#### 8.2. Removed libraries/classes
+- The `grails-web-fileupload` library, including its sole class `ContentLengthAwareCommonsMultipartResolver`, has been removed. This change was necessitated by the removal of the superclass `CommonsMultipartResolver` in Spring 6. The `ContentLengthAwareCommonsMultipartResolver` was originally introduced to address a bug in Safari back in 2007, but it is likely no longer needed. Spring has transitioned away from `CommonsMultipartResolver` and now recommends using the built-in support for multipart uploads provided by servlet containers. For more information on handling file uploads in Spring Boot, please refer to the relevant sections of the https://docs.spring.io/spring-boot/how-to/spring-mvc.html#howto.spring-mvc.multipart-file-uploads[Spring Boot documentation] and the https://github.com/spring-projects/spring-framework/wiki/Upgrading-to-Spring-Framework-6.x#web-applications-1[Spring Framework 6 upgrade guide].
 - `org.grails.spring.beans.factory.OptimizedAutowireCapableBeanFactory` was deprecated and is now removed.


### PR DESCRIPTION
This commit adds information to the breaking changes section about the removal of `grails-web-fileupload` in Grails 7.

Closes: #905