### PR TITLE
update versions for grails 6.2.2 release

### DIFF
--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,2 +1,2 @@
 groovyVersion=3.0.23
-grailsDocsVersion=6.2.2
+grailsDocsVersion=6.2.2-SNAPSHOT

--- a/buildSrc/gradle.properties
+++ b/buildSrc/gradle.properties
@@ -1,2 +1,2 @@
-groovyVersion=3.0.21
-grailsDocsVersion=6.2.1
+groovyVersion=3.0.23
+grailsDocsVersion=6.2.2

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-grails.version=6.2.2
+grails.version=6.2.2-SNAPSHOT
 githubSlug=grails/grails-doc
 githubBranch=6.2.x
 springBootVersion=2.7.18

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,12 +1,12 @@
-grails.version=6.2.2-SNAPSHOT
+grails.version=6.2.2
 githubSlug=grails/grails-doc
 githubBranch=6.2.x
 springBootVersion=2.7.18
 springVersion=5.3.39
 gradleVersion=7.6.4
 gormVersion=8.1.2
-groovyVersion=3.0.21
-gspVersion=6.2.3
+groovyVersion=3.0.23
+gspVersion=6.2.4
 org.gradle.caching=true
 org.gradle.daemon=true
 org.gradle.jvmargs=-Dfile.encoding=UTF-8 -Xmx1536M -XX:MaxMetaspaceSize=768M

--- a/src/en/guide/introduction/whatsNew/dependencyUpgrades.adoc
+++ b/src/en/guide/introduction/whatsNew/dependencyUpgrades.adoc
@@ -1,12 +1,12 @@
 Grails {version} ships with the following dependency upgrades:
 
-* Groovy 3.0.21
+* Groovy 3.0.23
 * Micronaut 3.10.4
 * Micronaut for Spring 4.5.1
 * GORM 8.1.2
 * Spring Framework 5.3.39
 * Spring Boot 2.7.18
 * Gradle 7.6.4
-* Spock 2.1-groovy-3.0
-* Grails Testing Support 3.2.1
+* Spock 2.3-groovy-3.0
+* Grails Testing Support 3.2.2
 


### PR DESCRIPTION
has to reference 6.2.2-SNAPSHOT since 6.2.2 has not yet been released