### PR TITLE
pull from repo.grails.org to speed up release process

### DIFF
--- a/buildSrc/src/main/groovy/grails/doc/DownloadPomTask.groovy
+++ b/buildSrc/src/main/groovy/grails/doc/DownloadPomTask.groovy
@@ -45,7 +45,7 @@ abstract class DownloadPomTask extends DefaultTask {
         if (version.endsWith('-SNAPSHOT')) {
             pomUrl = "https://repo.grails.org/ui/api/v1/download?repoKey=core&path=org%252Fgrails%252Fgrails-bom%252F${version}%252Fgrails-bom-${version}.pom&isNativeBrowsing=true"
         } else {
-            pomUrl = "https://repo1.maven.org/maven2/org/grails/grails-bom/${version}/grails-bom-${version}.pom"
+            pomUrl = "https://repo.grails.org/grails/core/org/grails/grails-bom/${version}/grails-bom-${version}.pom"
         }
 
         def pomContent = downloadPomContent(pomUrl)


### PR DESCRIPTION
 instead of waiting on mavenCentral.

```
Caused by: java.io.FileNotFoundException: https://repo1.maven.org/maven2/org/grails/grails-bom/6.2.2/grails-bom-6.2.2.pom
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at grails.doc.DownloadPomTask.downloadPomContent(DownloadPomTask.groovy:61)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at grails.doc.DownloadPomTask.downloadPom(DownloadPomTask.groovy:51)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at org.gradle.internal.reflect.JavaMethod.invoke(JavaMethod.java:125)
```