### PR TITLE
restore grails-shell cli command and profiles documentation

### DIFF
--- a/src/en/guide/REST/angularJsProfile.adoc
+++ b/src/en/guide/REST/angularJsProfile.adoc
@@ -1,0 +1,94 @@
+Since Grails 3.1, Grails supports a profile for creating applications with AngularJS that provides a more focused set of dependencies and commands. The angular profile inherits from the REST profile and therefore has all of the commands and properties that the REST profile has.
+
+To get started with the AngularJS profile, create an application specifying `angularjs` as the name of the profile:
+
+[source,bash]
+----
+$ grails create-app my-api --profile angularjs
+----
+
+This will create a new Grails application that provides the following features:
+
+* Default set of commands for creating AngularJS artefacts
+* Gradle plugin to manage client side dependencies
+* Gradle plugin to execute client side unit tests
+* Asset Pipeline plugins to ease development
+
+By default the AngularJS profile includes GSP support in order to render the index page. This is necessary because the profile is designed around asset pipeline.
+
+The new commands are:
+
+* `create-ng-component`
+* `create-ng-controller`
+* `create-ng-directive`
+* `create-ng-domain`
+* `create-ng-module`
+* `create-ng-service`
+
+
+
+==== Project structure
+
+
+The AngularJS profile is designed around a specific project structure. The `create-ng` commands will automatically create modules where they do not exist.
+
+Example:
+[source,bash]
+----
+$ grails create-ng-controller foo
+----
+
+This will produce a `fooController.js` file in `grails-app/assets/javascripts/${default package name}/controllers`.
+
+NOTE: By default the angularjs profile will create files in the `javascripts` directory. You can change that behavior in your configuration with the key `grails.codegen.angular.assetDir`.
+
+[source,bash]
+----
+$ grails create-ng-domain foo.bar
+----
+
+This will produce a `Bar.js` file in `grails-app/assets/javascripts/foo/domains`. It will also create the "foo" module if it does not already exist.
+
+[source,bash]
+----
+$ grails create-ng-module foo.bar
+----
+
+This will produce a `foo.bar.js` file in `grails-app/assets/javascripts/foo/bar`. Note the naming convention for modules is different than other artefacts.
+
+[source,bash]
+----
+$ grails create-ng-service foo.bar --type constant
+----
+
+This will produce a `bar.js` file in `grails-app/assets/javascripts/foo/services`. It will also create the "foo" module if it does not already exist. The `create-ng-service` command accepts a flag `-type`. The types that can be used are:
+
+* service
+* factory _default_
+* value
+* provider
+* constant
+
+Along with the artefacts themselves, the profile will also produce a skeleton unit test file under `src/test/javascripts` for each create command.
+
+
+==== Client side dependencies
+
+
+The https://github.com/craigburke/bower-installer-gradle[Gradle Bower Plugin] is used to manage dependencies with bower. Visit the plugin documentation to learn how to use the plugin.
+
+
+==== Unit Testing
+
+
+The https://github.com/craigburke/karma-gradle[Gradle Karma Plugin] is used to execute client side unit tests. All generated tests are written with Jasmine. Visit the plugin documentation to learn how to use the plugin.
+
+
+==== Asset Pipeline
+
+
+The AngularJS profile includes several asset pipeline plugins to make development easier.
+
+* https://github.com/craigburke/js-closure-wrap-asset-pipeline[JS Closure Wrap Asset Pipeline] will wrap your Angular code in immediately invoked function expressions.
+* https://github.com/craigburke/angular-annotate-asset-pipeline[Annotate Asset Pipeline] will annotate your dependencies to be safe for minification.
+* https://github.com/craigburke/angular-template-asset-pipeline[Template Asset Pipeline] will put your templates into the `$templateCache` to prevent http requests to retrieve the templates.

--- a/src/en/guide/REST/angularProfile.adoc
+++ b/src/en/guide/REST/angularProfile.adoc
@@ -1,0 +1,94 @@
+Since Grails 3.2.1, Grails supports a profile for creating applications with Angular that provides a more future facing setup.
+
+The biggest change in this profile is that the profile creates a multi project gradle build. This is the first profile to have done so. The Angular profile relies on the https://github.com/angular/angular-cli[Angular CLI] to manage the client side application. The server side application is the same as an application created with the `rest-api` profile.
+
+To get started with the Angular profile, create an application specifying `angular` as the name of the profile:
+
+[source,bash]
+----
+$ grails create-app my-app --profile angular
+----
+
+This will create a `my-app` directory with the following contents:
+
+[source]
+----
+client/
+gradle/
+gradlew
+gradlew.bat
+server/
+settings.gradle
+----
+
+The entire client application lives in the `client` folder and the entire server application lives in the `server` folder.
+
+==== Prerequisites
+
+To use this profile, you should have Node, NPM, and the Angular CLI installed. Node should be at least version 5 and NPM should be at least version 3.
+
+* https://docs.npmjs.com/getting-started/installing-node[Node && NPM]
+* https://github.com/angular/angular-cli#installation[Angular CLI]
+
+==== Project Structure
+
+The Angular profile is designed to be used with the https://github.com/angular/angular-cli[Angular CLI]. The CLI was used to create the client application side of the profile to start with. The CLI provides commands to do most of the things you would want to do with the client application, including creating components or services. Because of that, the profile itself provides no commands to do those same things.
+
+==== Running The App
+
+To execute the server side application only, you can execute the `bootRun` task in the `server` project:
+
+[source,bash]
+----
+./gradlew server:bootRun
+----
+
+The same can be done for the client application:
+
+[source,bash]
+----
+./gradlew client:bootRun
+----
+
+To execute both, you must do so in parallel:
+
+[source,bash]
+----
+./gradlew bootRun --parallel
+----
+
+NOTE: It is necessary to do so in parallel because by default Gradle executes tasks synchronously, and neither of the `bootRun` tasks will "finish".
+
+==== Testing
+
+The default client application that comes with the profile provides some tests that can be executed. To execute tests in the application:
+
+[source,bash]
+----
+./gradlew test
+----
+
+The `test` task will execute unit tests with Karma and Jasmine.
+
+[source,bash]
+----
+./gradlew integrationTest
+----
+
+The `integrationTest` task will execute e2e tests with Protractor.
+
+TIP: You can execute the `test` and `integrationTest` tasks on each of the sub-projects the same as you would `bootRun`.
+
+==== CORS
+
+Because the client side and server side will be running on separate ports, CORS configuration is required. By default the profile will configure the server side to allow CORS from all hosts via the following config:
+
+[source,yaml]
+.server/grails-app/conf/application.yml
+----
+grails:
+    cors:
+        enabled: true
+----
+
+See the section on link:theWebLayer.html#cors[CORS] in the user guide for information on configuring this feature for your needs.

--- a/src/en/guide/REST/jsonViews/jsonViewsSetup.adoc
+++ b/src/en/guide/REST/jsonViews/jsonViewsSetup.adoc
@@ -1,4 +1,4 @@
-If you are using the REST application, then the JSON views plugin will already be included and you can skip the remainder of this section. Otherwise you will need to modify your `build.gradle` to include the necessary plugin to activate JSON views:
+If you are using the REST application or REST or AngularJS profiles, then the JSON views plugin will already be included and you can skip the remainder of this section. Otherwise you will need to modify your `build.gradle` to include the necessary plugin to activate JSON views:
 
 [source,groovy]
 ----

--- a/src/en/guide/REST/restProfile.adoc
+++ b/src/en/guide/REST/restProfile.adoc
@@ -1,5 +1,36 @@
 Since Grails 3.1, Grails supports a tailored profile for creating REST applications that provides a more focused set of dependencies and commands.
 
+To get started with the REST profile, create an application specifying `rest-api` as the name of the profile:
+
+[source,bash]
+----
+$ grails create-app my-api --profile rest-api
+----
+
+This will create a new REST application that provides the following features:
+
+* Default set of commands for creating and generating REST endpoints
+* Defaults to using JSON views for rendering responses (see the next section)
+* Fewer plugins than the default Grails plugin (no GSP, no Asset Pipeline, nothing HTML related)
+
+You will notice for example in the `grails-app/views` directory that there are `*.gson` files for rendering the default index page and as well as any 404 and 500 errors.
+
+If you issue the following set of commands:
+
+[source,bash]
+----
+$ grails create-domain-class my.api.Book
+$ grails generate-all my.api.Book
+----
+
+Instead of CRUD HTML interface a REST endpoint is generated that produces JSON responses. In addition, the generated functional and unit tests by default test the REST endpoint.
+
+
+
+
+
+Using Grails Forge, Grails supports a tailored profile for creating REST applications that provides a more focused set of dependencies and commands.
+
 To get started with a REST API-type application:
 
 [source,console]

--- a/src/en/guide/commandLine.adoc
+++ b/src/en/guide/commandLine.adoc
@@ -1,4 +1,110 @@
-The Grails New Command-Line Interface (CLI) has undergone significant changes compared to its previous versions, primarily focusing on code generation. One notable alteration is the removal of APIs for invoking Gradle for tasks related to building using Gradle Tooling APIs. This shift in responsibility aligns with the framework's evolution and its integration with the Gradle build system.
+Grails 3.0's command line system differs greatly from previous versions of Grails and features APIs for invoking Gradle for build related tasks, as well as performing code generation.
+
+When you type:
+
+[source,groovy]
+----
+grails <<command name>>
+----
+
+Grails searches the http://bintray.com/grails/profiles[profile repository] based on the profile of the current application. If the profile is for a web application then commands are read from the web profile and the base profile which it inherits from.
+
+Since command behavior is profile specific the web profile may provide different behavior for the `run-app` command then say a profile for running batch applications.
+
+When you type the following command:
+
+[source,groovy]
+----
+grails run-app
+----
+
+It will first search the application, and then the profile for commands:
+
+* `PROJECT_HOME/src/main/scripts/run-app.groovy`
+* `<<profile>>/commands/run-app.groovy`
+* `<<profile>>/commands/run-app.yml`
+
+To get a list of all commands and some help about the available commands type:
+
+[source,bash]
+----
+grails help
+----
+
+which outputs usage instructions and the list of commands Grails is aware of:
+
+[source,bash]
+----
+grails <<environment>>* <<target>> <<arguments>>*'
+
+| Examples:
+$ grails dev run-app
+$ grails create-app books
+
+| Available Commands (type grails help 'command-name' for more info):
+| Command Name                          Command Description
+----------------------------------------------------------------------------------------------------
+clean                                   Cleans a Grails application's compiled sources
+compile                                 Compiles a Grails application
+...
+----
+
+NOTE: Refer to the Command Line reference in the Quick Reference menu of the reference guide for more information about individual commands
+
+=== Arguments
+
+The `grails` command is a front to a `gradle` invocation, because of this there can be unexpected side-effects.
+For example, when executing `grails -Dapp.foo=bar run-app` the `app.foo` system property won't be available to your application. This is because `bootRun` in your `build.gradle` configures the system properties.
+To make this work you can simply append all `System.properties` to `bootRun` in `build.gradle` like:
+
+[source,groovy]
+----
+bootRun{
+    systemProperties System.properties // Please note not to use '=', because this will override all configured systemProperties. This will append them.
+}
+----
+
+Or if you only want to pass through a limited set, you can prefix your system properties using an arbitrary prefix and configure `bootRun` like:
+
+[source,groovy]
+----
+bootRun{
+    bootRun {
+        systemProperties System.properties.inject([:]){acc,item-> item.key.startsWith('boot.')?acc << [(item.key.substring('boot.'.length())):item.value]:acc }
+    }
+}
+----
+
+In this example only system properties starting with `boot.` are passed through.
+
+Application and JVM arguments should be specified in `bootRun` as well.
+
+[source,groovy]
+----
+bootRun{
+    bootRun {
+        jvmArgs('-Dspring.output.ansi.enabled=always')
+        args('--app.foo=bar','--app.bar=foo') // Override the `app.foo` and `app.bar` config options (`grailsApplication.config`)
+    }
+}
+----
+
+
+=== non-interactive mode
+
+
+When you run a script manually and it prompts you for information, you can answer the questions and continue running the script. But when you run a script as part of an automated process, for example a continuous integration build server, there's no way to "answer" the questions. So you can pass the `\--non-interactive` switch to the script command to tell Grails to accept the default answer for any questions, for example whether to install a missing plugin.
+
+For example:
+
+[source,groovy]
+----
+grails war --non-interactive
+----
+
+
+
+The Grails Forge New Command-Line Interface (CLI) has undergone significant changes compared to its previous versions, primarily focusing on code generation. One notable alteration is the removal of APIs for invoking Gradle for tasks related to building using Gradle Tooling APIs. This shift in responsibility aligns with the framework's evolution and its integration with the Gradle build system.
 
 === Accessing the Grails CLI
 

--- a/src/en/guide/commandLine/creatingCustomCommands.adoc
+++ b/src/en/guide/commandLine/creatingCustomCommands.adoc
@@ -1,4 +1,60 @@
-In Grails, a custom command is a piece of functionality that you can add to your Grails application and execute via the command-line interface (CLI). These commands are not part of the core Grails framework but are extensions you can create to perform specific tasks or operations that are unique to your application's requirements. Custom commands are a powerful way to automate various tasks, interact with your application, and perform administrative functions from the command line. When you run custom commands, they cause the Grails environment to start, giving you full access to the application context and the runtime, allowing you to work with the application's resources, services, and configuration as needed within your custom command.
+
+You can create your own commands by running the <<ref-command-line-create-command,create-command>> command from the root of your project. For example the following command will create a command called `grails-app/commands/HelloWorldCommand`:
+
+[source,groovy]
+----
+grails create-command HelloWorld
+----
+
+NOTE: Unlike scripts, commands cause the Grails environment to start and you have full access to the application context and the runtime.
+
+Since Grails 3.2.0, commands have similar abilities as scripts in regards to retrieving arguments, template generation, file access, and model building.
+
+If you created a command in a previous version of grails, you can update your command to have those abilities by changing which trait you are implementing.
+
+Commands created in Grails 3.1.x or lower implement the http://docs.grails.org/latest/api/grails/dev/commands/ApplicationCommand.html[ApplicationCommand] trait by default which requires your command to implement the following method:
+
+[source,groovy]
+----
+boolean handle(ExecutionContext executionContext)
+----
+
+Commands created in Grails 3.2.0 or higher implement the http://docs.grails.org/latest/api/grails/dev/commands/GrailsApplicationCommand.html[GrailsApplicationCommand] trait by default which requires your command to implement the following method:
+
+[source,groovy]
+----
+boolean handle()
+----
+
+NOTE: Commands defined this way still have access to the execution context via a variable called "executionContext".
+
+Custom commands can be executed using *grails run-command*:
+
+[source]
+----
+grails run-command my-example
+----
+
+Commands can also be executed using the *runCommand* gradle task. Note that the gradle task uses camelCase:
+
+[source]
+----
+gradle runCommand -Pargs="my-example"
+----
+
+If the grails server is a subproject (e.g., in a project created with the *angular* profile), the subproject command can still be invoked from the gradle wrapper in the parent project:
+
+[source]
+----
+./gradlew server:runCommand -Pargs="my-example"
+----
+
+
+
+
+
+
+With Gradle, a custom command is a piece of functionality that you can add to your Grails application and execute via the command-line interface (CLI). These commands are not part of the core Grails framework but are extensions you can create to perform specific tasks or operations that are unique to your application's requirements. Custom commands are a powerful way to automate various tasks, interact with your application, and perform administrative functions from the command line. When you run custom commands, they cause the Grails environment to start, giving you full access to the application context and the runtime, allowing you to work with the application's resources, services, and configuration as needed within your custom command.
 
 There are several reasons why you might want to write a custom command for your Grails application:
 

--- a/src/en/guide/commandLine/creatingCustomScripts.adoc
+++ b/src/en/guide/commandLine/creatingCustomScripts.adoc
@@ -1,0 +1,111 @@
+
+You can create your own Command scripts by running the link:../ref/Command%20Line/create-script.html[create-script] command from the root of your project. For example the following command will create a script called `src/main/scripts/hello-world.groovy`:
+
+[source,groovy]
+----
+grails create-script hello-world
+----
+
+NOTE: In general Grails scripts should be used for scripting the Gradle based build system and code generation. Scripts cannot load application classes and in fact should not since Gradle is required to construct the application classpath.
+
+See below for an example script that prints "Hello World":
+
+[source,groovy]
+----
+description "Example description", "grails hello-world"
+
+println "Hello World"
+----
+
+The `description` method is used to define the output seen by `grails help` and to aid users of the script. The following is a more complete example of providing a description taken from the `generate-all` command:
+
+[source,groovy]
+----
+description( "Generates a controller that performs CRUD operations and the associated views" ) {
+  usage "grails generate-all <<DOMAIN CLASS>>"
+  flag name:'force', description:"Whether to overwrite existing files"
+  argument name:'Domain Class', description:'The name of the domain class'
+}
+----
+
+As you can see this description profiles usage instructions, a flag and an argument. This allows the command to be used as follows:
+
+[source,groovy]
+----
+grails generate-all MyClass --force
+----
+
+
+==== Template Generation
+
+
+Plugins and applications that need to define template generation tasks can do so using scripts. A example of this is the Scaffolding plugin which defines the `generate-all` and `generate-controllers` commands.
+
+Every Grails script implements the {apiDocs}org/grails/cli/profile/commands/templates/TemplateRenderer.html[TemplateRenderer] interface which makes it trivial to render templates to the users project workspace.
+
+The following is an example of the link:../ref/Command%20Line/create-script.html[create-script] command written in Groovy:
+
+[source,groovy]
+----
+description( "Creates a Grails script" ) {
+  usage "grails create-script <<SCRIPT NAME>>"
+  argument name:'Script Name', description:"The name of the script to create"
+  flag name:'force', description:"Whether to overwrite existing files"
+}
+
+def scriptName = args[0]
+def model = model(scriptName)
+def overwrite = flag('force') ? true : false
+
+render  template: template('artifacts/Script.groovy'),
+        destination: file("src/main/scripts/${model.lowerCaseName}.groovy"),
+        model: model,
+        overwrite: overwrite
+----
+
+If a script is defined in a plugin or profile, the `template(String)` method will search for the template in the application before using the template provided by your plugin or profile. This allows users of your plugin or profile to customize what gets generated.
+
+It is common to provide an easy way to allow users to copy the templates from your plugin or profile. Here is one example on how the angular scaffolding copies templates.
+
+[source,groovy]
+----
+templates("angular/**/*").each { Resource r ->
+    String path = r.URL.toString().replaceAll(/^.*?META-INF/, "src/main")
+    if (path.endsWith('/')) {
+        mkdir(path)
+    } else {
+        File to = new File(path)
+        SpringIOUtils.copy(r, to)
+        println("Copied ${r.filename} to location ${to.canonicalPath}")
+    }
+}
+----
+
+
+==== The "model"
+
+
+Executing the `model` method with a `Class`/`String`/`File`/`Resource` will return an instance of {apiDocs}grails/codegen/model/Model.html[Model]. The model contains several properties that can help you generate code.
+
+Example:
+
+[source,groovy]
+----
+def domain = model(com.foo.Bar)
+
+domain.className == "FooBar"
+domain.fullName == "com.foo.FooBar"
+domain.packageName == "com.foo"
+domain.packagePath == "com/foo"
+domain.propertyName == "fooBar"
+domain.lowerCaseName == "foo-bar"
+----
+
+In addition, an `asMap` method is available to turn all of the properties into a map to pass to the `render` method.
+
+
+==== Working with files
+
+
+All scripts have access to methods on the {apiDocs}org/grails/cli/profile/commands/io/FileSystemInteraction.html[FileSystemInteraction] class. It contains helpful methods to copy, delete, and create files.
+

--- a/src/en/guide/commandLine/gradleBuild/gradlePlugins.adoc
+++ b/src/en/guide/commandLine/gradleBuild/gradlePlugins.adoc
@@ -26,8 +26,12 @@ The default plugins are as follows:
 
 Many of these are built in plugins provided by Gradle or third party plugins. The Gradle plugins that Grails provides are as follows:
 
+* `org.grails.grails-doc` - A plugin for Gradle for using Grails 2.0's documentation engine.
 * `org.grails.grails-gsp` - The Grails GSP plugin adds pre-compilation of GSP files for production deployments.
 * `org.grails.grails-plugin` - A plugin for Gradle for building Grails plugins.
 * `org.grails.grails-web` - The Grails Web gradle plugin configures Gradle to understand the Grails conventions and directory structure.
+* `org.grails.grails-plugin-publish` - A plugin for publishing Grails plugins to the central repository.
+* `org.grails.grails-profile` - A plugin for use when creating Grails <<profiles,Profiles>>.
+* `org.grails.grails-profile-publish` - A plugin for publishing Grails profiles to the central repository.
 
 

--- a/src/en/guide/commandLine/gradleBuild/gradlePlugins.adoc.rej
+++ b/src/en/guide/commandLine/gradleBuild/gradlePlugins.adoc.rej
@@ -1,0 +1,49 @@
+diff a/src/en/guide/commandLine/gradleBuild/gradlePlugins.adoc b/src/en/guide/commandLine/gradleBuild/gradlePlugins.adoc	(rejected hunks)
+@@ -2,28 +2,32 @@
+ 
+ [source,groovy]
+ ----
+-apply plugin:"war"
+-apply plugin:"org.grails.grails-web"
+-apply plugin:"org.grails.grails-gsp"
+-apply plugin:"asset-pipeline"
++plugins {
++    id "groovy"
++    id "org.grails.grails-web"
++    id "org.grails.grails-gsp"
++    id "com.github.erdi.webdriver-binaries"
++    id "war"
++    id "idea"
++    id "com.bertramlabs.asset-pipeline"
++    id "application"
++    id "eclipse"
++}
+ ----
+ 
+ The default plugins are as follows:
+-
+-* `war` - The http://www.gradle.org/docs/current/userguide/war_plugin.html[WAR plugin] changes the packaging so that Gradle creates as WAR file from your application. You can comment out this plugin if you wish to create only a runnable JAR file for standalone deployment.
+-* `asset-pipeline` - The https://grails.org/plugins.html#plugin/asset-pipeline[asset pipeline] plugin enables the compilation of static assets (JavaScript, CSS etc.)
+-
++* `groovy` - The Groovy plugin add support for Groovy projects. It can deal with Groovy code mixed with Groovy and Java. Read More: https://docs.gradle.org/{gradleVersion}/userguide/groovy_plugin.html[The Groovy Plugin]
++* `com.github.erdi.webdriver-binaries` - A plugin that downloads and caches WebDriver binaries specific to the OS the build runs on. Read More at https://github.com/erdi/webdriver-binaries-gradle-plugin/blob/master/README.md[GitHub README]
++* `war` - The https://docs.gradle.org/{gradleVersion}/userguide/war_plugin.html[The WAR plugin] changes the packaging so that Gradle creates as WAR file from your application. You can comment out this plugin if you wish to create only a runnable JAR file for standalone deployment.
++* `idea` - The IDEA plugin generates files that are used by http://www.jetbrains.com/idea/[IntelliJ IDEA], thus making it possible to open the project from IDEA. Read More: https://docs.gradle.org/{gradleVersion}/userguide/idea_plugin.html[The IDEA Plugin]
++* `com.bertramlabs.asset-pipeline` - The https://grails.org/plugins.html#plugin/asset-pipeline[asset pipeline] plugin enables the compilation of static assets (JavaScript, CSS etc.)
++* `application` - The Application plugin facilitates creating an executable JVM application. Read More: https://docs.gradle.org/{gradleVersion}/userguide/application_plugin.html[The Application Plugin]
++* `eclipse` - The Eclipse plugins generate files that are used by the http://eclipse.org/[Eclipse IDE], thus making it possible to import the project into Eclipse (File - Import... - Existing Projects into Workspace). Read More: https://docs.gradle.org/{gradleVersion}/userguide/eclipse_plugin.html[The Eclipse Plugin]
+ 
+ Many of these are built in plugins provided by Gradle or third party plugins. The Gradle plugins that Grails provides are as follows:
+ 
+-* `org.grails.grails-core` - The primary Grails plugin for Gradle, included by all other plugins and designed to operate with all profiles.
+-* `org.grails.grails-gsp` - The Grails GSP plugin adds precompilation of GSP files for production deployments.
+-* `org.grails.grails-doc` - A plugin for Gradle for using Grails 2.0's documentation engine.
++* `org.grails.grails-gsp` - The Grails GSP plugin adds pre-compilation of GSP files for production deployments.
+ * `org.grails.grails-plugin` - A plugin for Gradle for building Grails plugins.
+-* `org.grails.grails-plugin-publish` - A plugin for publishing Grails plugins to the central repository.
+-* `org.grails.grails-profile` - A plugin for use when creating Grails <<profiles,Profiles>>.
+-* `org.grails.grails-profile-publish` - A plugin for publishing Grails profiles to the central repository.
+ * `org.grails.grails-web` - The Grails Web gradle plugin configures Gradle to understand the Grails conventions and directory structure.
+ 
+ 
+-

--- a/src/en/guide/commandLine/interactiveMode.adoc
+++ b/src/en/guide/commandLine/interactiveMode.adoc
@@ -1,4 +1,27 @@
-When you execute the `grails` command without any arguments, the Grails Command Line Interface (CLI) enters interactive mode. In this mode, it functions like a shell, allowing you to run multiple CLI commands without the need to re-initialize the CLI runtime. This mode is particularly useful when working with code-generation commands (such as `create-controller`), creating multiple projects, or exploring various CLI features.
+Interactive mode is a feature of the Grails command line which keeps the JVM running and allows for quicker execution of commands. To activate interactive mode type 'grails' at the command line and then use TAB completion to get a list of commands:
+
+image::interactive-output.png[]
+
+If you need to open a file whilst within interactive mode you can use the `open` command which will TAB complete file paths:
+
+image::interactive-open-cmd.png[]
+
+Even better, the `open` command understands the logical aliases 'test-report' and 'dep-report', which will open the most recent test and dependency reports respectively. In other words, to open the test report in a browser simply execute `open test-report`. You can even open multiple files at once: `open test-report test/unit/MyTests.groovy` will open the HTML test report in your browser and the `MyTests.groovy` source file in your text editor.
+
+TAB completion also works for class names after the `create-*` commands:
+
+image::interactive-complete-class.png[]
+
+If you need to run an external process whilst interactive mode is running you can do so by starting the command with a !:
+
+image::interactive-run-external.png[]
+
+Note that with ! (bang) commands, you get file path auto completion - ideal for external commands that operate on the file system such as 'ls', 'cat', 'git', etc.
+
+To exit interactive mode enter the `exit` command. Note that if the Grails application has been run with `run-app` normally it will terminate when the interactive mode console exits because the JVM will be terminated. An exception to this would be if the application were running in forked mode which means the application is running in a different JVM. In that case the application will be left running after the interactive mode console terminates. If you want to exit interactive mode and stop an application that is running in forked mode, use the `quit` command. The `quit` command will stop the running application and then close interactive mode.
+
+
+With Grails Forge, when you execute the `grails` command without any arguments, the Grails Command Line Interface (CLI) enters interactive mode. In this mode, it functions like a shell, allowing you to run multiple CLI commands without the need to re-initialize the CLI runtime. This mode is particularly useful when working with code-generation commands (such as `create-controller`), creating multiple projects, or exploring various CLI features.
 
 One of the advantages of interactive mode is the availability of tab-completion. You can simply press the TAB key to view possible options for a given command or flag. Here's an example of the available options in interactive mode:
 

--- a/src/en/guide/conf/applicationClass/executing.adoc
+++ b/src/en/guide/conf/applicationClass/executing.adoc
@@ -1,8 +1,14 @@
 There are several ways to execute the `Application` class, if you are using an IDE then you can simply right click on the class and run it directly from your IDE which will start your Grails application.
 
-This is also useful for debugging since you can debug directly from the IDE without having to connect a remote debugger when using the `./gradlew bootRun --debug-jvm` command from the command line.
+This is also useful for debugging since you can debug directly from the IDE without having to connect a remote debugger when using the `run-app --debug-jvm` or `./gradlew bootRun --debug-jvm` command from the command line.
 
 You can also package your application into a runnable WAR file, for example:
+
+[source,bash]
+----
+$ grails package
+$ java -jar build/libs/myapp-0.1.war
+----
 
 [source,bash]
 ----

--- a/src/en/guide/conf/config/ymlOptions.adoc
+++ b/src/en/guide/conf/config/ymlOptions.adoc
@@ -15,7 +15,7 @@ production:
 
 Similarly system arguments can be accessed.
 
-You will need to have this in `build.gradle` to modify the `bootRun` target if `./gradlew bootRun` is used to start the application
+You will need to have this in `build.gradle` to modify the `bootRun` target if `grails run-app` or `./gradlew bootRun` is used to start the application
 
 [source,groovy]
 ----

--- a/src/en/guide/conf/environments.adoc
+++ b/src/en/guide/conf/environments.adoc
@@ -85,6 +85,11 @@ To target other environments you can pass a `grails.env` variable to any command
 
 [source,bash]
 ----
+grails -Dgrails.env=UAT run-app
+----
+
+[source,bash]
+----
 ./gradlew bootRun -Dgrails.env=UAT
 ----
 

--- a/src/en/guide/contributing/build.adoc
+++ b/src/en/guide/contributing/build.adoc
@@ -101,9 +101,21 @@ Use "Import->General->Existing Projects into Workspace" to import all projects t
 
 
 To enable debugging, run:
+
+[source,groovy]
+----
+grails run-app --debug-jvm
+----
+
 [source,groovy]
 ----
 ./gradlew bootRun --debug-jvm
 ----
 
+By default Grails forks a JVM to run the application in. The `-debug-jvm` argument causes the debugger to be associated with the forked JVM.  In order to instead attach the debugger to the build system which is going to fork the JVM use the `-debug` option:
+
+[source,groovy]
+----
+grails -debug run-app
+----
 By default Grails forks a JVM to run the application in. The `-debug-jvm` argument causes the debugger to be associated with the forked JVM.

--- a/src/en/guide/deployment/deploymentStandalone.adoc
+++ b/src/en/guide/deployment/deploymentStandalone.adoc
@@ -1,5 +1,50 @@
 
 
+=== "grails run-app"
+
+
+You should be very familiar with this approach by now, since it is the most common method of running an application during the development phase. An embedded Tomcat server is launched that loads the web application from the development sources, thus allowing it to pick up any changes to application files.
+
+You can run the application in the production environment using:
+
+[source,groovy]
+----
+grails prod run-app
+----
+
+You can run the app using the `bootRun` Gradle task. The next command uses the https://docs.gradle.org/current/userguide/gradle_wrapper.html[Gradle Wrapper].
+
+`./gradlew bootRun`
+
+You can specify an environment supplying `grails.env` system property.
+
+`./gradlew -Dgrails.env=prod bootRun`
+
+=== Runnable WAR or JAR file
+
+Another way to deploy in Grails 3.0 or above is to use the new support for runnable JAR or WAR files. To create runnable archives, run `grails package`:
+
+[source,xml]
+----
+grails package
+----
+
+Alternatively, you could use the `assemble` Gradle task.
+
+`./gradlew assemble`
+
+You can then run either the WAR file or the JAR using your Java installation:
+
+[source,groovy]
+----
+java -Dgrails.env=prod -jar build/libs/mywar-0.1.war    (or .jar)
+----
+
+=== A TAR/ZIP distribution
+
+WARNING: Note: TAR/ZIP distribution assembly has been removed from Grails 3.1.
+
+
 === "./gradlew bootRun"
 
 

--- a/src/en/guide/gettingStarted/aHelloWorldExample.adoc
+++ b/src/en/guide/gettingStarted/aHelloWorldExample.adoc
@@ -134,6 +134,11 @@ server:
 
 With this configuration, the application will be available at:
 
+Alternatively, you can also set the context path via the command line:
+[source,bash]
+----
+grails> run-app -Dgrails.server.servlet.context-path=/helloworld
+----
 http://localhost:8080/myapp/
 
 Alternatively, you can set the context path from the command line when using Gradle to run a Grails application. Here's how you can do it:

--- a/src/en/guide/gettingStarted/conventionOverConfiguration.adoc
+++ b/src/en/guide/gettingStarted/conventionOverConfiguration.adoc
@@ -18,4 +18,6 @@ Grails adopts the "convention over configuration" approach to configure itself. 
 
 4.  `src/integration-test/groovy` - link:testing.html#integrationTests[Integration Tests] - For testing Grails applications at the integration level.
 
+5.  `src/main/scripts` - link:commandLine.html[Code generation scripts].
+
 Understanding this directory structure and its conventions is fundamental to efficient Grails development.

--- a/src/en/guide/gettingStarted/deployingAnApplication.adoc
+++ b/src/en/guide/gettingStarted/deployingAnApplication.adoc
@@ -1,4 +1,55 @@
-Grails applications offer multiple deployment options.
+Grails applications can be deployed in a number of different ways.
+
+If you are deploying to a traditional container (Tomcat, Jetty etc.) you can create a Web Application Archive (WAR file), and Grails includes the link:../ref/Command%20Line/war.html[war] command for performing this task:
+
+[source,bash]
+----
+grails war
+----
+
+This will produce a WAR file under the `build/libs` directory which can then be deployed as per your container's instructions.
+
+Note that by default Grails will include an embeddable version of Tomcat inside the WAR file, this can cause problems if you deploy to a different version of Tomcat. If you don't intend to use the embedded container then you should change the scope of the Tomcat dependencies to `testImplementation` (or `provided` if using Grails 4.x) prior to deploying to your production container in `build.gradle`:
+
+[source,groovy]
+----
+testImplementation "org.springframework.boot:spring-boot-starter-tomcat"
+----
+
+If you are building a WAR file to deploy on Tomcat 7 then in addition you will need to change the target Tomcat version in the build. Grails is built against Tomcat 8 APIs by default.
+To target a Tomcat 7 container, insert a line to `build.gradle` above the `dependencies { }` section:
+[source,groovy]
+----
+ext['tomcat.version'] = '7.0.59'
+----
+WARNING: Grails 5 contains dependencies that _require_ `javax.el-api:3.0` (eg.: `datastore-gorm:7.x`, `spring-boot:2.x`) which is only supported starting from Tomcat 8.x+, based on the http://tomcat.apache.org/whichversion.html[tomcat version table]!
+
+Unlike most scripts which default to the `development` environment unless overridden, the `war` command runs in the `production` environment by default. You can override this like any script by specifying the environment name, for example:
+
+[source,bash]
+----
+grails dev war
+----
+
+If you prefer not to operate a separate Servlet container then you can simply run the Grails WAR file as a regular Java application. Example:
+
+[source,bash]
+----
+grails war
+java -Dgrails.env=prod -jar build/libs/mywar-0.1.war
+----
+
+
+When deploying Grails you should always run your containers JVM with the `-server` option and with sufficient memory allocation. A good set of VM flags would be:
+
+[source,bash]
+----
+-server -Xmx768M
+----
+
+
+
+Via Gradle, Grails applications offer multiple deployment options.
 
 For traditional container deployments, such as Tomcat or Jetty, you can generate a Web Application Archive (WAR) file using the Gradle `war` task as follows:
 

--- a/src/en/guide/gettingStarted/generatingAnApplication.adoc
+++ b/src/en/guide/gettingStarted/generatingAnApplication.adoc
@@ -1,5 +1,16 @@
 === Quick Start with Grails Scaffolding
 
+To get started quickly with Grails it is often useful to use a feature called link:scaffolding.html[scaffolding] to generate the skeleton of an application. To do this use one of the `generate-*` commands such as link:../ref/Command%20Line/generate-all.html[generate-all], which will generate a link:theWebLayer.html#controllers[controller] (and its unit test) and the associated link:theWebLayer.html#gsp[views]:
+
+[source,groovy]
+----
+grails generate-all helloworld.Book
+----
+
+
+
+=== Gradle Quick Start with Grails Scaffolding
+
 To quickly initiate your Grails project, you can employ the `runCommand` Gradle task. This task allows you to generate the essential structure of an application swiftly. Specifically, when running the following command, you can create a link:theWebLayer.html#controllers[controller] (including its unit tests) and the associated link:theWebLayer.html#gsp[views] for your application:
 
 [source,console]

--- a/src/en/guide/gettingStarted/runningAndDebuggingAnApplication.adoc
+++ b/src/en/guide/gettingStarted/runningAndDebuggingAnApplication.adoc
@@ -1,4 +1,45 @@
-Grails applications can be executed using the built-in application server using the `bootRun` command. By default, it launches a server on port 8080:
+Grails applications can be run with the built in Tomcat server using the link:../ref/Command%20Line/run-app.html[run-app] command which will load a server on port 8080 by default:
+
+[source,bash]
+----
+grails run-app
+----
+
+You can specify a different port by using the `-port` argument:
+
+[source,bash]
+----
+grails run-app -port=8090
+----
+
+Note that it is better to start up the application in interactive mode since a container restart is much quicker:
+
+[source,bash]
+----
+$ grails
+grails> run-app
+| Grails application running at http://localhost:8080 in environment: development
+grails> stop-app
+| Shutting down application...
+| Application shutdown.
+grails> run-app
+| Grails application running at http://localhost:8080 in environment: development
+----
+
+You can debug a grails app by simply right-clicking on the `Application.groovy` class in your IDE and choosing the appropriate action (since Grails 3).
+
+Alternatively, you can run your app with the following command and then attach a remote debugger to it.
+
+[source,bash]
+----
+grails run-app --debug-jvm
+----
+
+More information on the link:../ref/Command%20Line/run-app.html[run-app] command can be found in the reference guide.
+
+
+
+Via Gradle, Grails applications can be executed using the built-in application server using the `bootRun` command. By default, it launches a server on port 8080:
 
 [source,console]
 $ ./gradlew bootRun

--- a/src/en/guide/gettingStarted/testingAnApplication.adoc
+++ b/src/en/guide/gettingStarted/testingAnApplication.adoc
@@ -1,4 +1,14 @@
-Grails offers a convenient feature where you can automatically generate unit and integration tests for your application using the `create-*` commands. These generated tests are stored in the `src/test/groovy` and `src/integration-test/groovy` directories. However, it is your responsibility to populate these tests with the appropriate test logic. You can find comprehensive guidance on crafting valid test logic in the section dedicated to link:testing.html[Unit and Integration Tests].
+The `create-*` commands in Grails automatically create unit or integration tests for you within the `src/test/groovy` directory. It is of course up to you to populate these tests with valid test logic, information on which can be found in the section on link:testing.html[Unit and integration tests].
+
+To execute tests you run the link:../ref/Command%20Line/test-app.html[test-app] command as follows:
+
+[source,groovy]
+----
+grails test-app
+----
+
+
+Gradle offers a convenient feature where you can automatically generate unit and integration tests for your application using the `create-*` commands. These generated tests are stored in the `src/test/groovy` and `src/integration-test/groovy` directories. However, it is your responsibility to populate these tests with the appropriate test logic. You can find comprehensive guidance on crafting valid test logic in the section dedicated to link:testing.html[Unit and Integration Tests].
 
 To initiate the execution of your tests, including both unit and integration tests, you can utilize the Gradle `check` task. Follow these steps:
 

--- a/src/en/guide/gettingStarted/usingInteractiveMode.adoc
+++ b/src/en/guide/gettingStarted/usingInteractiveMode.adoc
@@ -1,4 +1,11 @@
-The Grails Command-line Interface (CLI) offers an interactive mode, which you can access by entering "grails" in your Terminal application or Linux Command Line.
+Since 3.0, Grails has an interactive mode which makes command execution faster since the JVM doesn't have to be restarted for each command. To use interactive mode simple type 'grails' from the root of any projects and use TAB completion to get a list of available commands. See the screenshot below for an example:
+
+image::interactive-output.png[]
+
+For more information on the capabilities of interactive mode refer to the section on link:commandLine.html#interactiveMode[Interactive Mode] in the user guide.
+
+
+The Grails Forge Command-line Interface (CLI) offers an interactive mode, which you can access by entering "grails" in your Terminal application or Linux Command Line.
 
 Once you're in the command-line interface, you can enhance your efficiency by utilizing the TAB key for auto-completion. For instance:
 

--- a/src/en/guide/index.adoc
+++ b/src/en/guide/index.adoc
@@ -226,10 +226,55 @@ include::conf/dependencyResolution.adoc[]
 
 include::commandLine.adoc[]
 
+[[interactiveMode]]
+=== Interactive Mode
+
+include::commandLine/interactiveMode.adoc[]
+
+[[creatingCustomScripts]]
+=== Creating Custom Scripts
+
+include::commandLine/creatingCustomScripts.adoc[]
+
 [[creatingCustomCommands]]
 === Creating Custom Commands
 
 include::commandLine/creatingCustomCommands.adoc[]
+
+[[profiles]]
+== Application Profiles
+
+include::profiles.adoc[]
+
+[[creatingProfiles]]
+=== Creating Profiles
+
+include::profiles/creatingProfiles.adoc[]
+
+[[profileInheritance]]
+=== Profile Inheritance
+
+include::profiles/profileInheritance.adoc[]
+
+[[publishingProfiles]]
+=== Publishing Profiles
+
+include::profiles/publishingProfiles.adoc[]
+
+[[profileStructure]]
+=== Understanding Profiles
+
+include::profiles/profileStructure.adoc[]
+
+[[profileCommands]]
+=== Creating Profile Commands
+
+include::profiles/profileCommands.adoc[]
+
+[[profileFeatures]]
+=== Creating Profile Features
+
+include::profiles/profileFeatures.adoc[]
 
 [[GORM]]
 == Object Relational Mapping (GORM)
@@ -615,6 +660,16 @@ include::webServices/REST/restfulControllers/restControllersStepByStep.adoc[]
 ===== Generating a REST controller using scaffolding
 
 include::webServices/REST/restfulControllers/generatingRestControllers.adoc[]
+
+[[restProfile]]
+==== The REST Profile
+
+include::webServices/REST/restProfile.adoc[]
+
+[[angularProfile]]
+==== The Angular Profile
+
+include::webServices/REST/angularProfile.adoc[]
 
 [[jsonViews]]
 ==== JSON Views
@@ -1132,10 +1187,35 @@ include::contributing/patchesDoc.adoc[]
 [[ref-command-line]]
 === Command Line
 
+[[ref-command-line-bug-report]]
+==== bug-report
+
+include::ref/Command Line/bug-report.adoc[]
+
+[[ref-command-line-clean]]
+==== clean
+
+include::ref/Command Line/clean.adoc[]
+
+[[ref-command-line-compile]]
+==== compile
+
+include::ref/Command Line/compile.adoc[]
+
+[[ref-command-line-console]]
+==== console
+
+include::ref/Command Line/console.adoc[]
+
 [[ref-command-line-create-app]]
 ==== create-app
 
 include::ref/Command Line/create-app.adoc[]
+
+[[ref-command-line-create-command]]
+==== create-command
+
+include::ref/Command Line/create-command.adoc[]
 
 [[ref-command-line-create-controller]]
 ==== create-controller
@@ -1147,15 +1227,165 @@ include::ref/Command Line/create-controller.adoc[]
 
 include::ref/Command Line/create-domain-class.adoc[]
 
+[[ref-command-line-create-functional-test]]
+==== create-functional-test
+
+include::ref/Command Line/create-functional-test.adoc[]
+
+[[ref-command-line-create-hibernate-cfg-xml]]
+==== create-hibernate-cfg-xml
+
+include::ref/Command Line/create-hibernate-cfg-xml.adoc[]
+
+[[ref-command-line-create-integration-test]]
+==== create-integration-test
+
+include::ref/Command Line/create-integration-test.adoc[]
+
+[[ref-command-line-create-interceptor]]
+==== create-interceptor
+
+include::ref/Command Line/create-interceptor.adoc[]
+
 [[ref-command-line-create-plugin]]
 ==== create-plugin
 
 include::ref/Command Line/create-plugin.adoc[]
 
+[[ref-command-line-create-profile]]
+==== create-profile
+
+include::ref/Command Line/create-profile.adoc[]
+
+[[ref-command-line-create-script]]
+==== create-script
+
+include::ref/Command Line/create-script.adoc[]
+
+[[ref-command-line-create-service]]
+==== create-service
+
+include::ref/Command Line/create-service.adoc[]
+
+[[ref-command-line-create-taglib]]
+==== create-taglib
+
+include::ref/Command Line/create-taglib.adoc[]
+
+[[ref-command-line-create-unit-test]]
+==== create-unit-test
+
+include::ref/Command Line/create-unit-test.adoc[]
+
+[[ref-command-line-dependency-report]]
+==== dependency-report
+
+include::ref/Command Line/dependency-report.adoc[]
+
+[[ref-command-line-docs]]
+==== docs
+
+include::ref/Command Line/docs.adoc[]
+
+[[ref-command-line-generate-all]]
+==== generate-all
+
+include::ref/Command Line/generate-all.adoc[]
+
+[[ref-command-line-generate-controller]]
+==== generate-controller
+
+include::ref/Command Line/generate-controller.adoc[]
+
+[[ref-command-line-generate-views]]
+==== generate-views
+
+include::ref/Command Line/generate-views.adoc[]
+
 [[ref-command-line-help]]
 ==== help
 
 include::ref/Command Line/help.adoc[]
+
+[[ref-command-line-install-templates]]
+==== install-templates
+
+include::ref/Command Line/install-templates.adoc[]
+
+[[ref-command-line-list-plugins]]
+==== list-plugins
+
+include::ref/Command Line/list-plugins.adoc[]
+
+[[ref-command-line-list-profiles]]
+==== list-profiles
+
+include::ref/Command Line/list-profiles.adoc[]
+
+[[ref-command-line-package-plugin]]
+==== package-plugin
+
+include::ref/Command Line/package-plugin.adoc[]
+
+[[ref-command-line-package]]
+==== package
+
+include::ref/Command Line/package.adoc[]
+
+[[ref-command-line-plugin-info]]
+==== plugin-info
+
+include::ref/Command Line/plugin-info.adoc[]
+
+[[ref-command-line-profile-info]]
+==== profile-info
+
+include::ref/Command Line/profile-info.adoc[]
+
+[[ref-command-line-run-app]]
+==== run-app
+
+include::ref/Command Line/run-app.adoc[]
+
+[[ref-command-line-run-command]]
+==== run-command
+
+include::ref/Command Line/run-command.adoc[]
+
+[[ref-command-line-run-script]]
+==== run-script
+
+include::ref/Command Line/run-script.adoc[]
+
+[[ref-command-line-schema-export]]
+==== schema-export
+
+include::ref/Command Line/schema-export.adoc[]
+
+[[ref-command-line-shell]]
+==== shell
+
+include::ref/Command Line/shell.adoc[]
+
+[[ref-command-line-stats]]
+==== stats
+
+include::ref/Command Line/stats.adoc[]
+
+[[ref-command-line-stop-app]]
+==== stop-app
+
+include::ref/Command Line/stop-app.adoc[]
+
+[[ref-command-line-test-app]]
+==== test-app
+
+include::ref/Command Line/test-app.adoc[]
+
+[[ref-command-line-war]]
+==== war
+
+include::ref/Command Line/war.adoc[]
 
 [[ref-constraints]]
 === Constraints

--- a/src/en/guide/plugins/creatingAndInstallingPlugins.adoc
+++ b/src/en/guide/plugins/creatingAndInstallingPlugins.adoc
@@ -22,6 +22,344 @@ Make sure the plugin name does not contain more than one capital letter in a row
 
 Being a regular Grails project has a number of benefits in that you can immediately test your plugin by running (if the plugin targets the "web" profile):
 
+[source,groovy]
+----
+grails run-app
+----
+
+NOTE: Plugin projects don't provide an index.gsp by default since most plugins don't need it. So, if you try to view the plugin running in a browser right after creating it, you will receive a page not found error. You can easily create a `grails-app/views/index.gsp` for your plugin if you'd like.
+
+The structure of a Grails plugin is very nearly the same as a Grails application project's except that in the `src/main/groovy` directory under the plugin package structure you will find a plugin descriptor class (a class that ends in "GrailsPlugin"). For example:
+
+[source,groovy]
+----
+import grails.plugins.*
+
+class ExampleGrailsPlugin extends Plugin {
+   ...
+}
+----
+
+All plugins must have this class under the `src/main/groovy` directory, otherwise they are not regarded as a plugin. The plugin class defines metadata about the plugin, and optionally various hooks into plugin extension points (covered shortly).
+
+You can also provide additional information about your plugin using several special properties:
+
+* `title` - short one-sentence description of your plugin
+* `grailsVersion` - The version range of Grails that the plugin supports. eg. "1.2 > *" (indicating 1.2 or higher)
+* `author` - plugin author's name
+* `authorEmail` - plugin author's contact e-mail
+* `developers` - Any additional developers beyond the author specified above.
+* `description` - full multi-line description of plugin's features
+* `documentation` - URL of the plugin's documentation
+* `license` - License of the plugin
+* `issueManagement` - Issue Tracker of the plugin
+* `scm` - Source code management location of the plugin
+
+Here is a slimmed down example from the https://github.com/grails-plugins/grails-quartz[Quartz Grails plugin]:
+
+[source,groovy]
+----
+package quartz
+
+@Slf4j
+class QuartzGrailsPlugin extends Plugin {
+    // the version or versions of Grails the plugin is designed for
+    def grailsVersion = "3.0.0.BUILD-SNAPSHOT > *"
+    // resources that are excluded from plugin packaging
+    def pluginExcludes = [
+            "grails-app/views/error.gsp"
+    ]
+    def title = "Quartz" // Headline display name of the plugin
+    def author = "Jeff Brown"
+    def authorEmail = "zzz@yyy.com"
+    def description = '''\
+Adds Quartz job scheduling features
+'''
+    def profiles = ['web']
+    List loadAfter = ['hibernate3', 'hibernate4', 'hibernate5', 'services']
+    def documentation = "http://grails.org/plugin/quartz"
+    def license = "APACHE"
+    def issueManagement = [ system: "Github Issues", url: "http://github.com/grails3-plugins/quartz/issues" ]
+    def developers = [
+            [ name: "Joe Dev", email: "joedev@gmail.com" ]
+    ]
+    def scm = [ url: "https://github.com/grails3-plugins/quartz/" ]
+
+    Closure doWithSpring()......
+----
+
+==== Plugin Configuration
+
+Instead of directly accessing Grails configuration as `grailsApplication.config.mail.hostName`, use a Spring Boot configuration bean (or a POJO) annotated with {springbootapi}/org/springframework/boot/context/properties/ConfigurationProperties.html[ConfigurationProperties] annotation. Here is an example plugin configuration:
+
+_./src/main/groovy/example/MailPluginConfiguration.groovy_
+[source,groovy]
+```
+package example
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "mail")
+class MailPluginConfiguration {
+
+    String hostName
+    int port
+    String from
+}
+
+```
+
+You can inject the `MailPluginConfiguration` bean into your bean like any other bean.
+
+_./grails-app/services/example/MailService.groovy_
+[source,groovy]
+```
+package example
+
+class MailService {
+
+    MailPluginConfiguration mailPluginConfiguration
+
+    void sendMail() {
+
+    }
+
+}
+```
+
+Please read the {springBootReference}/html/features.html#features.external-config[Spring Boot Externalized Configuration] section for more information.
+
+==== Installing Local Plugins
+
+In order to install the Grails plugin to your local Maven, you could use Gradle https://docs.gradle.org/current/userguide/publishing_maven.html[Maven Publish] plugin. You may also need to configure the publishing extension as:
+
+[source,groovy]
+----
+publishing {
+    publications {
+        maven(MavenPublication) {
+            versionMapping {
+                usage('java-api') {
+                    fromResolutionOf('runtimeClasspath')
+                }
+                usage('java-runtime') {
+                    fromResolutionResult()
+                }
+            }
+            from components.java
+        }
+    }
+}
+----
+
+NOTE: Please refer to the Gradle Maven Publish plugin documentation for up-to-date information.
+
+To make your plugin available for use in a Grails application run the `./gradlew publishToMavenLocal` command:
+
+[source,bash]
+----
+./gradlew publishToMavenLocal
+----
+
+This will install the plugin into your local Maven cache. Then to use the plugin within an application declare a dependency on the plugin in your `build.gradle` file and include `mavenLocal()` in your repositories hash:
+
+[source,groovy]
+----
+...
+repositories {
+    ...
+    mavenLocal()
+}
+...
+implementation "org.grails.plugins:quartz:0.1"
+----
+
+NOTE: In Grails 2.x plugins were packaged as ZIP files, however in Grails 3.x plugins are simple JAR files that can be added to the classpath of the IDE.
+
+
+
+==== Plugins and Multi-Project Builds
+
+
+If you wish to setup a plugin as part of a multi project build then follow these steps.
+
+*Step 1: Create the application and the plugin*
+
+Using the `grails` command create an application and a plugin:
+
+[source,groovy]
+----
+$ grails create-app myapp
+$ grails create-plugin myplugin
+----
+
+*Step 2: Create a settings.gradle file*
+
+In the same directory create a `settings.gradle` file with the following contents:
+
+[source,groovy]
+----
+include "myapp", "myplugin"
+----
+
+The directory structure should be as follows:
+
+[source,groovy]
+----
+PROJECT_DIR
+  - settings.gradle
+  - myapp
+    - build.gradle
+  - myplugin
+    - build.gradle
+----
+
+*Step 3: Declare a project dependency on the plugin*
+
+Within the `build.gradle` of the application declare a dependency on the plugin within the `plugins` block:
+
+[source,groovy]
+----
+grails {
+    plugins {
+        implementation project(':myplugin')
+    }
+}
+----
+
+NOTE: You can also declare the dependency within the `dependencies` block, however you will not get subproject reloading if you do this!
+
+*Step 4: Configure the plugin to enable reloading*
+
+In the plugin directory, add or modify the `gradle.properties` file. A new property `exploded=true` needs to be set in order for the plugin to add the exploded directories to the classpath.
+
+*Step 5: Run the application*
+
+Now run the application using the `grails run-app` command from the root of the application directory, you can use the `verbose` flag to see the Gradle output:
+
+[source,groovy]
+----
+$ cd myapp
+$ grails run-app -verbose
+----
+
+You will notice from the Gradle output that plugins sources are built and placed on the classpath of your application:
+
+[source,groovy]
+----
+:myplugin:compileAstJava UP-TO-DATE
+:myplugin:compileAstGroovy UP-TO-DATE
+:myplugin:processAstResources UP-TO-DATE
+:myplugin:astClasses UP-TO-DATE
+:myplugin:compileJava UP-TO-DATE
+:myplugin:configScript UP-TO-DATE
+:myplugin:compileGroovy
+:myplugin:copyAssets UP-TO-DATE
+:myplugin:copyCommands UP-TO-DATE
+:myplugin:copyTemplates UP-TO-DATE
+:myplugin:processResources
+:myapp:compileJava UP-TO-DATE
+:myapp:compileGroovy
+:myapp:processResources UP-TO-DATE
+:myapp:classes
+:myapp:findMainClass
+:myapp:bootRun
+Grails application running at http://localhost:8080 in environment: development
+----
+
+
+==== Notes on excluded Artefacts
+
+
+Although the link:../ref/Command%20Line/create-plugin.html[create-plugin] command creates certain files for you so that the plugin can be run as a Grails application, not all of these files are included when packaging a plugin. The following is a list of artefacts created, but not included by link:../ref/Command%20Line/package-plugin.html[package-plugin]:
+
+* `grails-app/build.gradle` (although it is used to generate `dependencies.groovy`)
+* `grails-app/conf/application.yml` (renamed to plugin.yml)
+* `grails-app/conf/spring/resources.groovy`
+* `grails-app/conf/logback.groovy`
+* Everything within `/src/test/\*\*`
+* SCM management files within `\*\*/.svn/\*\*` and `\*\*/CVS/\*\*`
+
+
+==== Customizing the plugin contents
+
+
+When developing a plugin you may create test classes and sources that are used during the development and testing of the plugin but should not be exported to the application.
+
+To exclude test sources you need to modify the `pluginExcludes` property of the plugin descriptor AND exclude the resources inside your `build.gradle` file. For example say you have some classes under the `com.demo` package that are in your plugin source tree but should not be packaged in the application. In your plugin descriptor you should exclude these:
+
+[source,groovy]
+----
+// resources that should be loaded by the plugin once installed in the application
+  def pluginExcludes = [
+    '**/com/demo/**'
+  ]
+----
+
+And in your `build.gradle` you should exclude the compiled classes from the JAR file:
+
+[source,groovy]
+----
+jar {
+  exclude "com/demo/**/**"
+}
+----
+
+
+
+==== Inline Plugins in Grails 3.0
+
+
+In Grails 2.x it was possible to specify inline plugins in `BuildConfig`, in Grails 3.x this functionality has been replaced by Gradle's multi-project build feature.
+
+To set up a multi project build create an appliation and a plugin in a parent directory:
+
+[source,groovy]
+----
+$ grails create-app myapp
+$ grails create-plugin myplugin
+----
+
+Then create a `settings.gradle` file in the parent directory specifying the location of your application and plugin:
+
+[source,groovy]
+----
+include 'myapp', 'myplugin'
+----
+
+Finally add a dependency in your application's `build.gradle` on the plugin:
+
+[source,groovy]
+----
+implementation project(':myplugin')
+----
+
+Using this technique you have achieved the equivalent of inline plugins from Grails 2.x.
+
+
+==== Grails Forge Creating Plugins
+
+
+Creating a Grails plugin is a simple matter of running the command:
+
+[source,groovy]
+----
+grails create-plugin <<PLUGIN NAME>>
+----
+
+This will create a web-plugin project for the name you specify. For example running `grails create-plugin example` would create a new web-plugin project called `example`.
+
+In Grails 3.0 you should consider whether the plugin you create requires a web environment or whether the plugin can be used with other profiles. If your plugin does not require a web environment then use the "plugin" profile instead of the default "web-plugin" profile:
+
+[source,groovy]
+----
+grails create-plugin <<PLUGIN NAME>> --profile=plugin
+----
+
+Make sure the plugin name does not contain more than one capital letter in a row, or it won't work. Camel case is fine, though.
+
+Being a regular Grails project has a number of benefits in that you can immediately test your plugin by running (if the plugin targets the "web" profile):
+
 [source,shell]
 ----
 ./gradlew bootRun

--- a/src/en/guide/profiles.adoc
+++ b/src/en/guide/profiles.adoc
@@ -1,0 +1,113 @@
+When you create a Grails application with the link:../ref/Command%20Line/create-app.html[create-app] command by default the "web" profile is used:
+
+[source,bash]
+----
+grails create-app myapp
+----
+
+You can specify a different profile with the profile argument:
+
+[source,bash]
+----
+grails create-app myapp --profile=rest-api
+----
+
+Profiles encapsulate the project commands, templates and plugins that are designed to work for a given profile. The source for the profiles can be found https://github.com/grails-profiles[on Github], whilst the profiles themselves are published as JAR files to the Grails central repository.
+
+To find out what profiles are available use the link:../ref/Command%20Line/list-profiles.html[list-profiles] command:
+
+[source,bash]
+----
+$ grails list-profiles
+----
+
+For more information on a particular profile use the link:../ref/Command%20Line/profile-info.html[profile-info] command:
+
+[source,bash]
+----
+$ grails profile-info rest-api
+----
+
+NOTE: Commands such as `profile-info` or `list-profiles` are not available when you invoke the Grails CLI inside a grails project. 
+
+==== Profile Repositories
+
+
+By default Grails will resolve profiles from the https://repo.grails.org/grails/core/org/grails/profiles/[Grails central repository]. However, you can override what repositories will be searched by specifying repositories in the `USER_HOME/.grails/settings.groovy` file.
+
+If you want profiles to be resolved with a custom repository in addition to the Grails central repository, you must specify Grails central in the file as well:
+
+[source,groovy]
+----
+grails {
+  profiles {
+    repositories {
+      myRepo {
+        url = "http://foo.com/repo"
+        snapshotsEnabled = true
+      }
+      grailsCentral {
+        url = "https://repo.grails.org/grails/core"
+        snapshotsEnabled = true
+      }
+    }
+  }
+}
+----
+
+NOTE: Grails uses Aether to resolve profiles, as a Gradle instance is not yet available when the `create-app` command is executed. This means that you can also define repositories and more advanced configuration (proxies, authentication etc.) in your `USER_HOME/.m2/settings.xml` file if you wish.
+
+It is also possible to store simple credentials for profile repositories directly in the `USER_HOME/.grails/settings.groovy` file.
+
+[source,groovy]
+----
+grails {
+  profiles {
+    repositories {
+      myRepo {
+        url = "http://foo.com/repo"
+        snapshotsEnabled = true
+        username = "user"
+        password = "pass"
+      }
+      ...
+    }
+  }
+}
+----
+
+
+==== Profile Defaults
+
+
+To create an application that uses a custom profile, you must specify the full artifact.
+
+[source,bash]
+----
+$ grails create-app myapp --profile=com.mycompany.grails.profiles:myprofile:1.0.0
+----
+
+To make this process easier, you can define defaults for a given profile in the `USER_HOME/.grails/settings.groovy` file.
+
+[source,groovy]
+----
+grails {
+  profiles {
+    myprofile {
+      groupId = "com.mycompany.grails.profiles"
+      version = "1.0.0"
+    }
+    repositories {
+      ...
+    }
+  }
+}
+----
+
+With the default values specified, the command to create an application using that profile becomes:
+
+[source,bash]
+----
+$ grails create-app myapp --profile=myprofile
+----
+

--- a/src/en/guide/profiles.gdoc
+++ b/src/en/guide/profiles.gdoc
@@ -1,0 +1,102 @@
+When you create a Grails application with the [create-app|commandLine] command by default the "web" profile is used:
+
+{code}
+grails create-app myapp
+{code}
+
+You can specify a different profile with the profile argument:
+
+{code}
+grails create-app myapp --profile=rest-api
+{code}
+
+Profiles encapsulate the project commands, templates and plugins that are designed to work for a given profile. The source for the profiles can be found [on Github|https://github.com/grails/grails-profile-repository], whilst the profiles themselves are published as JAR files to the Grails central repository.
+
+To find out what profiles are available use the [list-profiles|commandLine] command:
+
+{code}
+$ grails list-profiles
+{code}
+
+For more information on a particular profile use the [profile-info|commandLine] command:
+
+{code}
+$ grails profile-info rest-api
+{code}
+
+
+h4. Profile Repositories
+
+By default Grails will resolve profiles from the [Grails central repository|https://repo.grails.org/grails/core/org/grails/profiles/]. However, you can override what repositories will be searched by specifying repositories in the @USER_HOME/.grails/settings.groovy@ file.
+
+If you want profiles to be resolved with a custom repository in addition to the Grails central repository, you must specify Grails central in the file as well:
+
+{code}
+grails {
+  profiles {
+    repositories {
+      myRepo {
+        url = "http://foo.com/repo"
+        snapshotsEnabled = true
+      }
+      grailsCentral {
+        url = "https://repo.grails.org/grails/core"
+        snapshotsEnabled = true
+      }
+    }
+  }
+}
+{code}
+
+{note}
+Note that Grails uses Aether to resolve profiles, as a Gradle instance is not yet available when the @create-app@ command is executed. This means that you can also define repositories and more advanced configuration (proxies, authentication etc.) in your @USER_HOME/.m2/settings.xml@ file if you wish.
+{note}
+
+It is also possible to store simple credentials for profile repositories directly in the @USER_HOME/.grails/settings.groovy@ file.
+
+{code}
+grails {
+  profiles {
+    repositories {
+      myRepo {
+        url = "http://foo.com/repo"
+        snapshotsEnabled = true
+        username = "user"
+        password = "pass"
+      }
+      ...
+    }
+  }
+}
+{code}
+
+h4. Profile Defaults
+
+To create an application that uses a custom profile, you must specify the full artifact.
+
+{code}
+$ grails create-app myapp --profile=com.mycompany.grails.profiles:myprofile:1.0.0
+{code}
+
+To make this process easier, you can define defaults for a given profile in the @USER_HOME/grails/settings.groovy@ file.
+
+{code}
+grails {
+  profiles {
+    myprofile {
+      groupId = "com.mycompany.grails.profiles"
+      version = "1.0.0"
+    }
+    repositories {
+      ...
+    }
+  }
+}
+{code}
+
+With the default values specified, the command to create an application using that profile becomes:
+
+{code}
+$ grails create-app myapp --profile=myprofile
+{code}
+

--- a/src/en/guide/profiles/creatingProfiles.adoc
+++ b/src/en/guide/profiles/creatingProfiles.adoc
@@ -1,0 +1,78 @@
+The idea behind creating a new profile is that you can setup a default set of commands and plugins that are tailored to a particular technology or organisation.
+
+To create a new profile you can use the link:../ref/Command%20Line/create-profile.html[create-profile] command which will create a new empty profile that extends the base profile:
+
+[source,bash]
+----
+$ grails create-profile mycompany
+----
+
+The above command will create a new profile in the "mycompany" directory where the command is executed. If you start interactive mode within the directory you will get a set of commands for creating profiles:
+
+[source,bash]
+----
+$ cd mycompany
+$ grails
+| Enter a command name to run. Use TAB for completion:
+grails>
+
+create-command      create-creator-command      create-feature      create-generator-command    create-gradle-command   create-template
+----
+
+The commands are as follows:
+
+* `create-command` - creates a new command that will be available from the Grails CLI when the profile is used
+* `create-creator-command` - creates a command available to the CLI that renders a template (Example: create-controller)
+* `create-generator-command` - creates a command available to the CLI that renders a template based on a domain class (Example: generate-controller)
+* `create-feature` - creates a feature that can be used with this profile
+* `create-gradle-command` - creates a CLI command that can invoke gradle
+* `create-template` - creates a template that can be rendered by a command
+
+
+To customize the dependencies for your profile you can specify additional dependencies in `profile.yml`.
+
+Below is an example `profile.yml` file:
+
+[source,yaml]
+----
+features:
+    defaults:
+        - hibernate
+        - asset-pipeline
+build:
+    plugins:
+        - org.grails.grails-web
+    excludes:
+        - org.grails.grails-core
+dependencies:
+    - scope: compile
+      coords: "org.mycompany:myplugin:1.0.1"
+    - scope: testCompile
+      coords: org.spockframework:spock-core
+      excludes:
+        - group: org.codehaus.groovy
+          module: groovy-all
+----
+
+With the above configuration in place you can publish the profile to your local repository with `gradle install`:
+
+[source,bash]
+----
+$ gradle install
+----
+
+Your profile is now usable with the `create-app` command:
+
+[source,bash]
+----
+$ grails create-app myapp --profile mycompany
+----
+
+With the above command the application will be created with the "mycompany" profile which includes an additional dependency on the "myplugin" plugin and also includes the "hibernate" and "asset-pipeline" features (more on features later).
+
+Note that if you customize the dependency coordinates of the profile (group, version etc.) then you may need to use the fully qualified coordinates to create an application:
+
+[source,bash]
+----
+$ grails create-app myapp --profile com.mycompany:mycompany:1.0.1
+----

--- a/src/en/guide/profiles/profileCommands.adoc
+++ b/src/en/guide/profiles/profileCommands.adoc
@@ -1,0 +1,65 @@
+A profile can define new commands that apply only to that profile using YAML or Groovy scripts. Below is an example of the link:../ref/Command%20Line/create-controller.html[create-controller] command defined in YAML:
+
+[source,yaml]
+----
+description:
+    - Creates a controller
+    - usage: 'create-controller <<controller name>>'
+    - completer: org.grails.cli.interactive.completers.DomainClassCompleter
+    - argument: "Controller Name"
+      description: "The name of the controller"
+steps:
+ - command: render
+   template: templates/artifacts/Controller.groovy
+   destination: grails-app/controllers/`artifact.package.path`/`artifact.name`Controller.groovy
+ - command: render
+   template: templates/testing/Controller.groovy
+   destination: src/test/groovy/`artifact.package.path`/`artifact.name`ControllerSpec.groovy
+ - command: mkdir
+   location: grails-app/views/`artifact.propertyName`
+----
+
+Commands defined in YAML must define one or many steps. Each step is a command in itself. The available step types are:
+
+* `render` - To render a template to a given destination (as seen in the previous example)
+* `mkdir` - To make a directory specified by the `location` parameter
+* `execute` - To execute a command specified by the `class` parameter. Must be a class that implements the {apiDocs}org/grails/cli/profile/Command.html[Command] interface.
+* `gradle` - To execute one or many Gradle tasks specified by the `tasks` parameter.
+
+For example to invoke a Gradle task, you can define the following YAML:
+
+[source,yaml]
+----
+description: Creates a WAR file for deployment to a container (like Tomcat)
+minArguments: 0
+usage: |
+ war
+steps:
+ - command: gradle
+   tasks:
+     - war
+----
+
+If you need more flexibility than what the declarative YAML approach provides you can create Groovy script commands. Each Command script is extends from the {apiDocs}org/grails/cli/profile/commands/script/GroovyScriptCommand.html[GroovyScriptCommand] class and hence has all of the methods of that class available to it.
+
+The following is an example of the link:../ref/Command%20Line/create-script.html[create-script] command written in Groovy:
+
+[source,groovy]
+----
+description( "Creates a Grails script" ) {
+  usage "grails create-script <<SCRIPT NAME>>"
+  argument name:'Script Name', description:"The name of the script to create"
+  flag name:'force', description:"Whether to overwrite existing files"
+}
+
+def scriptName = args[0]
+def model = model(scriptName)
+def overwrite = flag('force') ? true : false
+
+render  template: template('artifacts/Script.groovy'),
+        destination: file("src/main/scripts/${model.lowerCaseName}.groovy"),
+        model: model,
+        overwrite: overwrite
+----
+
+For more information on creating CLI commands see the section on link:commandLine.html#creatingCustomScripts[creating custom scripts] in the Command Line section of the user guide.

--- a/src/en/guide/profiles/profileFeatures.adoc
+++ b/src/en/guide/profiles/profileFeatures.adoc
@@ -1,0 +1,59 @@
+A Profile feature is a shareable set of templates and dependencies that may span multiple profiles. Typically you create a base profile that has multiple features and child profiles that inherit from the parent and hence can use the features available from the parent.
+
+To create a feature use the `create-feature` command from the root directory of your profile:
+
+[source,bash]
+----
+$ grails create-feature myfeature
+----
+
+This will create a `myfeature/feature.yml` file that looks like the following:
+
+[source,yaml]
+----
+description: Description of the feature
+# customize versions here
+# dependencies:
+#   - scope: compile
+#     coords: "org.grails.plugins:myplugin2:1.0"
+#
+----
+
+As a more concrete example. The following is the `feature.yml` file from the "asset-pipeline" feature:
+
+[source,yaml]
+----
+description: Adds Asset Pipeline to a Grails project
+build:
+    plugins:
+        - asset-pipeline
+dependencies:
+    - scope: build
+      coords: 'com.bertramlabs.plugins:asset-pipeline-gradle:2.5.0'
+    - scope: runtime
+      coords: "org.grails.plugins:asset-pipeline"
+----
+
+The structure of a feature is as follows:
+
+[source]
+----
+FEATURE_DIR
+    feature.yml
+    skeleton/
+        grails-app/
+            conf/
+                application.yml
+        build.gradle
+----
+
+The contents of the skeleton get copied into the application tree, whilst the `application.yml` and `build.gradle` get merged with their respective counterparts in the profile by used.
+
+With the `feature.yml` you can define additional dependencies. This allows users to create applications with optional features. For example:
+
+[source,bash]
+----
+$ grails create-app myapp --profile myprofile --features myfeature,hibernate
+----
+
+The above example will create a new application using your new feature and the "hibernate" feature.

--- a/src/en/guide/profiles/profileInheritance.adoc
+++ b/src/en/guide/profiles/profileInheritance.adoc
@@ -1,0 +1,28 @@
+One profile can extend one or many different parent profiles. To define profile inheritance you can modify the `build.gradle` of a profile and define the profile dependences. For example typically you want to extend the `base` profile:
+
+[source,groovy]
+----
+dependencies {
+    runtime "org.grails.profiles:base:$baseProfileVersion"
+}
+----
+
+By inheriting from a parent profile you get the following benefits:
+
+* When the link:../ref/Command%20Line/create-app.html[create-app] command is executed the parent profile's skeleton is copied first
+* Dependencies and `build.gradle` is merged from the parent(s)
+* The `application.yml` file is merged from the parent(s)
+* CLI commands from the parent profile are inherited
+* Features from the parent profile are inherited
+
+To define the order of inheritance ensure that your dependencies are declared in the correct order. For example:
+
+[source,groovy]
+----
+dependencies {
+    runtime "org.grails.profiles:plugin:$baseProfileVersion"
+    runtime "org.grails.profiles:web:$baseProfileVersion"
+}
+----
+
+In the above snippet the skeleton from the "plugin" profile is copied first, followed by the "web" profile. In addition, the "web" profile overrides commands from the "plugin" profile, whilst if the dependency order was reversed the "plugin" profile would override the "web" profile.

--- a/src/en/guide/profiles/profileStructure.adoc
+++ b/src/en/guide/profiles/profileStructure.adoc
@@ -1,0 +1,203 @@
+A profile is a simple directory that contains a `profile.yml` file and directories containing the "commands", "skeleton" and "templates" defined by the profile. Example:
+
+[source]
+----
+/web
+    commands/
+        create-controller.yml
+        run-app.groovy
+        ...
+    features/
+        asset-pipeline/
+            skeleton
+            feature.yml
+    skeleton/
+        grails-app/
+            controllers/
+            ...
+        build.gradle
+    templates/
+        artifacts/
+            Controller.groovy
+    profile.yml
+----
+
+The above example is a snippet of structure of the 'web' profile. The `profile.yml` file is used to describe the profile and control how the build is configured.
+
+
+==== Understanding the profile.yml descriptor
+
+
+The `profile.yml` can contain the following child elements.
+
+
+==== 1) repositories
+
+
+A list of Maven repositories to include in the generated build. Example:
+
+[source,yaml]
+----
+repositories:
+    - "https://repo.grails.org/grails/core"
+----
+
+
+==== 2) build.repositories
+
+
+A list of Maven repositories to include in the buildscript section of the generated build. Example:
+
+[source,yaml]
+----
+build:
+    repositories:
+        - "https://repo.grails.org/grails/core"
+----
+
+
+==== 3) build.plugins
+
+
+A list of Gradle plugins to configure in the generated build. Example:
+
+[source,yaml]
+----
+build:
+    plugins:
+        - eclipse
+        - idea
+        - org.grails.grails-core
+----
+
+
+==== 4) build.excludes
+
+
+A list of Gradle plugins to exclude from being inherited from the parent profile:
+
+[source,yaml]
+----
+build:
+    excludes:
+        - org.grails.grails-core
+----
+
+
+==== 5) dependencies
+
+
+A map of scopes and dependencies to configure. The `excludes` scope can be used to exclude from the parent profile. Example:
+
+[source,yaml]
+----
+dependencies:
+    - scope: excludes
+      coords: "org.grails:hibernate:*"
+    - scope: build
+      coords: "org.grails:grails-gradle-plugin:$grailsVersion"
+    - scope: compile
+      coords: "org.springframework.boot:spring-boot-starter-logging"
+    - scope: compile
+      coords: "org.springframework.boot:spring-boot-autoconfigure"
+----
+
+===== Excluding Transitive Dependencies
+
+To exclude transitive dependencies, define `excludes` key with a List of transitive dependencies Map of the dependency group, module, classifier, and `extension` as:
+
+[source,yaml]
+----
+dependencies:
+    - scope: testCompile
+      coords: org.spockframework:spock-core
+      excludes:
+        - group: org.codehaus.groovy
+          module: groovy-all
+----
+
+==== 6) features.defaults
+
+
+A default list of features to use if no explicit features are specified.
+
+[source,yaml]
+----
+features:
+    defaults: 
+        - hibernate
+        - asset-pipeline
+----
+
+
+==== 7) skeleton.excludes
+
+
+A list of files to exclude from parent profile's skeletons (supports wildcards).
+
+[source,groovy]
+----
+skeleton:
+    excludes:
+        - gradlew
+        - gradlew.bat
+        - gradle/
+----
+
+
+==== 8) skeleton.parent.target
+
+
+The target folder that parent profile's skeleton should be copied into. This can be used to create multi-project builds.
+
+[source,groovy]
+----
+skeleton:
+    parent:
+        target: app
+----
+
+
+==== 9) skeleton.binaryExtensions
+
+Which file extensions should be copied from the profile as binary. Inherited and combined from parent profiles.
+
+[source,groovy]
+----
+skeleton:
+    binaryExtensions: [exe, zip]
+----
+
+==== 10) skeleton.executable
+
+File patterns that should be marked as executable in the resulting application. Inherited and combined from parent profiles. The patterns are parsed with https://ant.apache.org/manual/dirtasks.html#patterns[Ant].
+
+[source,groovy]
+----
+skeleton:
+    executable:
+      - "**/gradlew*"
+      - "**/grailsw*"
+----
+
+==== 11) instructions
+
+
+Text to be displayed to the user after the application is created
+
+[source,groovy]
+----
+instructions: Here are some instructions
+----
+
+
+==== What happens when a profile is used?
+
+
+When the `create-app` command runs it takes the skeleton of the parent profiles and copies the skeletons into a new project structure. 
+
+The `build.gradle` file is generated is result of obtaining all of the dependency information defined in the `profile.yml` files and produces the required dependencies.
+
+The command will also merge any `build.gradle` files defined within a profile and its parent profiles.
+
+The `grails-app/conf/application.yml` file is also merged into a single YAML file taking into account the profile and all of the parent profiles.

--- a/src/en/guide/profiles/publishingProfiles.adoc
+++ b/src/en/guide/profiles/publishingProfiles.adoc
@@ -1,0 +1,62 @@
+
+==== Publishing Profiles to the Grails Central Repository
+
+
+Any profile created with the link:../ref/Command%20Line/create-profile.html[create-profile] command already comes configured with a `grails-profile-publish` plugin defined in `build.gradle`:
+
+[source,groovy]
+----
+apply plugin: "org.grails.grails-profile-publish"
+----
+
+To publish a profile using this plugin to the Grails central repository first upload the source to https://github.com[Github] (closed source profiles will not be accepted). Then register for an account on http://bintray.com[Bintray] and configure your keys as follows in the profile's `build.gradle` file:
+
+[source,groovy]
+----
+grailsPublish {
+  user = 'YOUR USERNAME'
+  key = 'YOUR KEY'
+  githubSlug = 'your-repo/your-profile'
+  license = 'Apache-2.0'
+}
+----
+
+NOTE: The `githubSlug` argument should point to the path to your Github repository. For example if your repository is located at https://github.com/foo/bar then your `githubSlug` is `foo/bar`
+
+With this in place you can run `gradle publishProfile` to publish your profile:
+
+[source,bash]
+----
+$ gradle publishProfile
+----
+
+The profile will be uploaded to Bintray. You can then go the https://github.com/grails-profiles[Grails profiles repository] and request to have your profile included by clicking "Include My Package" button on Bintray's interface (you must be logged in to see this).
+
+
+==== Publishing Profiles to an Internal Repository
+
+
+The aforementioned `grails-profile-publish` plugin configures https://docs.gradle.org/current/userguide/publishing_maven.html[Gradle's Maven Publish plugin]. In order to publish to an internal repository all you need to do is define the repository in `build.gradle`. For example:
+
+[source,groovy]
+----
+publishing {
+    repositories {
+        maven {
+            credentials {
+                username "foo"
+                password "bar"
+            }
+
+            url "http://foo.com/repo"
+        }
+    }
+}
+----
+
+Once configured you can publish your plugin with `gradle publish`:
+
+[source,bash]
+----
+$ gradle publish
+----

--- a/src/en/guide/reference.adoc
+++ b/src/en/guide/reference.adoc
@@ -4,14 +4,37 @@
 [[ref-command-line]]
 === Command Line
 
+[[ref-command-line-bug-report]]
+==== bug-report
+
+include::ref/Command Line/bug-report.adoc[]
+
+[[ref-command-line-clean]]
+==== clean
+
+include::ref/Command Line/clean.adoc[]
+
+[[ref-command-line-compile]]
+==== compile
+
+include::ref/Command Line/compile.adoc[]
+
+[[ref-command-line-console]]
+==== console
+
+include::ref/Command Line/console.adoc[]
+
 [[ref-command-line-create-app]]
 ==== create-app
 
 include::ref/Command Line/create-app.adoc[]
 
+[[ref-command-line-create-command]]
+==== create-command
 [[ref-command-line-assemble]]
 ==== assemble
 
+include::ref/Command Line/create-command.adoc[]
 include::ref/Command Line/assemble.adoc[]
 
 [[ref-command-line-create-controller]]
@@ -24,14 +47,42 @@ include::ref/Command Line/create-controller.adoc[]
 
 include::ref/Command Line/create-domain-class.adoc[]
 
+[[ref-command-line-create-functional-test]]
+==== create-functional-test
+
+include::ref/Command Line/create-functional-test.adoc[]
+
+[[ref-command-line-create-hibernate-cfg-xml]]
+==== create-hibernate-cfg-xml
+
+include::ref/Command Line/create-hibernate-cfg-xml.adoc[]
+
+[[ref-command-line-create-integration-test]]
+==== create-integration-test
+
+include::ref/Command Line/create-integration-test.adoc[]
+
+[[ref-command-line-create-interceptor]]
+==== create-interceptor
+
+include::ref/Command Line/create-interceptor.adoc[]
+
 [[ref-command-line-create-plugin]]
 ==== create-plugin
 
 include::ref/Command Line/create-plugin.adoc[]
 
+[[ref-command-line-create-profile]]
+==== create-profile
 [[ref-command-line-create-rest-api]]
 ==== create-rest-api
 
+include::ref/Command Line/create-profile.adoc[]
+
+[[ref-command-line-create-script]]
+==== create-script
+
+include::ref/Command Line/create-script.adoc[]
 include::ref/Command Line/create-rest-api.adoc[]
 
 [[ref-command-line-create-service]]
@@ -44,9 +95,22 @@ include::ref/Command Line/create-service.adoc[]
 
 include::ref/Command Line/create-taglib.adoc[]
 
+[[ref-command-line-create-unit-test]]
+==== create-unit-test
+
+include::ref/Command Line/create-unit-test.adoc[]
+
+[[ref-command-line-dependency-report]]
+==== dependency-report
+
+include::ref/Command Line/dependency-report.adoc[]
 [[ref-command-line-create-web-plugin]]
 ==== create-web-plugin
 
+[[ref-command-line-docs]]
+==== docs
+
+include::ref/Command Line/docs.adoc[]
 include::ref/Command Line/create-web-plugin.adoc[]
 
 [[ref-command-line-generate-all]]
@@ -75,19 +139,74 @@ include::ref/Command Line/help.adoc[]
 include::ref/Command Line/install-templates.adoc[]
 
 [[ref-command-line-list-plugins]]
+==== list-plugins
+
+include::ref/Command Line/list-plugins.adoc[]
+
+[[ref-command-line-list-profiles]]
+==== list-profiles
+
+include::ref/Command Line/list-profiles.adoc[]
+
+[[ref-command-line-package-plugin]]
+==== package-plugin
+
+include::ref/Command Line/package-plugin.adoc[]
+
+[[ref-command-line-package]]
+==== package
+
+include::ref/Command Line/package.adoc[]
+
+[[ref-command-line-plugin-info]]
+==== plugin-info
+
+include::ref/Command Line/plugin-info.adoc[]
+
+[[ref-command-line-profile-info]]
+==== profile-info
 ==== list-features
 
+include::ref/Command Line/profile-info.adoc[]
 include::ref/Command Line/list-features.adoc[]
 
+[[ref-command-line-run-app]]
+==== run-app
 [[ref-command-line-bootRun]]
 ==== bootRun
 
+include::ref/Command Line/run-app.adoc[]
 include::ref/Command Line/bootRun.adoc[]
 
 [[ref-command-line-schema-export]]
 ==== schema-export
 
 include::ref/Command Line/schema-export.adoc[]
+
+[[ref-command-line-shell]]
+==== shell
+
+include::ref/Command Line/shell.adoc[]
+
+[[ref-command-line-stats]]
+==== stats
+
+include::ref/Command Line/stats.adoc[]
+
+[[ref-command-line-stop-app]]
+==== stop-app
+
+include::ref/Command Line/stop-app.adoc[]
+
+[[ref-command-line-test-app]]
+==== test-app
+
+include::ref/Command Line/test-app.adoc[]
+
+[[ref-command-line-war]]
+==== war
+
+include::ref/Command Line/war.adoc[]
 
 [[ref-constraints]]
 === Constraints

--- a/src/en/guide/testing.adoc
+++ b/src/en/guide/testing.adoc
@@ -1,5 +1,166 @@
+Automated testing is a key part of Grails. Hence, Grails provides many ways to making testing easier from low level unit testing to high level functional tests. This section details the different capabilities that Grails offers for testing.
 
-Automated testing is a critical aspect of Grails development. Grails provides a rich set of testing capabilities, ranging from low-level unit testing to high-level functional tests. This comprehensive guide explores these diverse testing features in detail.
+The first thing to be aware of is that all of the `create-\*` and `generate-\*` commands create `unit` or `integration` tests automatically. For example if you run the link:../ref/Command%20Line/create-controller.html[create-controller] command as follows:
+
+[source,groovy]
+----
+grails create-controller com.acme.app.simple
+----
+
+Grails will create a controller at `grails-app/controllers/com/acme/app/SimpleController.groovy`, and also a unit test at `src/test/groovy/com/acme/app/SimpleControllerSpec.groovy`. What Grails won't do however is populate the logic inside the test! That is left up to you.
+
+NOTE: The default class name suffix is `Tests` but as of Grails 1.2.2, the suffix of `Test` is also supported.
+
+
+==== Running Tests
+
+
+Tests are run with the link:../ref/Command%20Line/test-app.html[test-app] command:
+
+[source,groovy]
+----
+grails test-app
+----
+
+The command will produce output such as:
+
+[source,groovy]
+----
+-------------------------------------------------------
+Running Unit Tests...
+Running test FooTests...FAILURE
+Unit Tests Completed in 464ms ...
+-------------------------------------------------------
+
+Tests failed: 0 errors, 1 failures
+----
+
+whilst showing the reason for each test failure.
+
+NOTE: You can force a clean before running tests by passing `-clean` to the `test-app` command.
+
+Grails writes HTML test reports to the `build/reports/tests` directory and JUnit XML test reports to the `build/test-results` directory. The HTML reports are generally the best ones to look at.
+
+Using Grails' link:commandLine.html#interactiveMode[interactive mode] confers some distinct advantages when executing tests. First, the tests will execute significantly faster on the second and subsequent runs. Second, a shortcut is available to open the HTML reports in your browser:
+
+[source,groovy]
+----
+open test-report
+----
+
+You can also run your unit tests from within most IDEs.
+
+
+==== Targeting Tests
+
+
+You can selectively target the test(s) to be run in different ways. To run all tests for a controller named `SimpleController` you would run:
+
+[source,groovy]
+----
+grails test-app SimpleController
+----
+
+This will run any tests for the class named `SimpleController`. Wildcards can be used...
+
+[source,groovy]
+----
+grails test-app *Controller
+----
+
+This will test all classes ending in `Controller`. Package names can optionally be specified...
+
+[source,groovy]
+----
+grails test-app some.org.*Controller
+----
+
+or to run all tests in a package...
+
+[source,groovy]
+----
+grails test-app some.org.*
+----
+
+or to run all tests in a package including subpackages...
+
+[source,groovy]
+----
+grails test-app some.org.**.*
+----
+
+You can also target particular test methods...
+
+[source,groovy]
+----
+grails test-app SimpleController.testLogin
+----
+
+This will run the `testLogin` test in the `SimpleController` tests. You can specify as many patterns in combination as you like...
+
+[source,groovy]
+----
+grails test-app some.org.* SimpleController.testLogin BookController
+----
+
+NOTE: In Grails 2.x, adding `-rerun` as an argument would only run those tests which failed in the previous test-app run. This argument is no longer supported.
+
+NOTE: In Grails 3.x, you might need to specify the package name before the class name, as well as append "Spec" to the end. For example, if you want to run the test for the ProductController, you should use `grails test-app *.ProductControllerSpec`. Note that the star can be used if you don't want to type the whole package hierarchy.
+
+
+==== Debugging
+
+
+In order to debug your tests via a remote debugger, you can add `--debug-jvm` after `grails` in any commands, like so:
+
+[source,groovy]
+----
+grails --debug-jvm test-app
+----
+
+This will open the default Java remote debugging port, 5005, for you to attach a remote debugger from your editor / IDE of choice.
+
+NOTE: This differs from Grails 2.3 and previous, where the `grails-debug` command existed.
+
+
+==== Targeting Test Phases
+
+
+In addition to targeting certain tests, you can also target test _phases._ By default Grails has two testing phases `unit` and `integration.`
+
+NOTE: Grails 2.x uses `phase:type` syntax. In Grails 3.0 it was removed, because it made no sense in Gradle context.
+
+To execute `unit` tests you can run:
+
+[source,groovy]
+----
+grails test-app -unit
+----
+
+To run `integration` tests you would run...
+
+[source,groovy]
+----
+grails test-app -integration
+----
+
+
+==== Targeting Tests When Using Phases
+
+
+Test and phase targeting can be applied at the same time:
+
+[source,groovy]
+----
+grails test-app some.org.**.* -unit
+----
+
+This would run all tests in the `unit` phase that are in the package `some.org` or a subpackage.
+
+
+
+
+With Gradle, automated testing is a critical aspect of Grails development. Grails provides a rich set of testing capabilities, ranging from low-level unit testing to high-level functional tests. This comprehensive guide explores these diverse testing features in detail.
 
 **Automatic Test Generation**
 

--- a/src/en/guide/toc.yml
+++ b/src/en/guide/toc.yml
@@ -54,8 +54,23 @@ conf:
 commandLine:
   title: The Command Line
   interactiveMode: Interactive Mode
+  creatingCustomScripts: Creating Custom Scripts
   creatingCustomCommands: Creating Custom Commands
   creatingProject: Creating a Grails Project
+  reusingGrailsScripts: Re-using Grails scripts
+  gradleBuild:
+    title: Building with Gradle
+    gradleDependencies: Defining Dependencies with Gradle
+    gradleTasks: Working with Gradle Tasks
+    gradlePlugins: Grails plugins for Gradle
+profiles:
+  title: Application Profiles
+  creatingProfiles: Creating Profiles
+  profileInheritance: Profile Inheritance
+  publishingProfiles: Publishing Profiles
+  profileStructure: Understanding Profiles
+  profileCommands: Creating Profile Commands
+  profileFeatures: Creating Profile Features
 GORM:
   title: Object Relational Mapping (GORM)
   quickStartGuide:
@@ -123,6 +138,8 @@ REST:
     generatingRestControllers: Generating a REST controller using scaffolding
   callingRestServices: Calling REST Services with HttpClient
   restProfile: The REST Profile
+  angularJsProfile: The AngularJS Profile
+  angularProfile: The Angular Profile
   jsonViews:
     title: JSON Views
     jsonViewsSetup: Getting Started

--- a/src/en/ref/Command Line.adoc
+++ b/src/en/ref/Command Line.adoc
@@ -2,6 +2,46 @@
 === Command Line Usage
 
 
+Grails incorporates the powerful build system http://gradle.org[Gradle].
+
+The basic usage scenario is:
+
+[source,groovy]
+----
+grails <<environment>>* <<command name>>
+----
+
+Grails searches in the following directories for Gant scripts to execute:
+
+* `USER_HOME/.grails/scripts`
+* `PROJECT_HOME/src/main/scripts/`
+* `PROJECT_HOME/plugins/*/scripts`
+* `GRAILS_HOME/scripts`
+
+If multiple matches are found Grails will give you a choice of which one to execute.
+
+You can specify the environment that the command executes in with an optional environment parameter, either with one of the built-in environment names:
+
+[source,groovy]
+----
+grails dev run-app
+grails test run-app
+grails prod run-app
+----
+
+Or using a -D argument if the name is not one of the three standard names:
+
+[source,groovy]
+----
+grails -Dgrails.env=uat run-app
+----
+
+Refer to the user guide section on link:{guidePath}/commandLine.html[The Command Line] for more information.
+
+
+=== Grails Forge Command Line Usage
+
+
 Grails incorporates a CLI and also uses the powerful build system https://gradle.org[Gradle].
 
 The basic usage scenario is:

--- a/src/en/ref/Command Line/bug-report.adoc
+++ b/src/en/ref/Command Line/bug-report.adoc
@@ -1,0 +1,27 @@
+
+== bug-report
+
+
+
+=== Purpose
+
+
+The bug-report command packages up the sources of your application (excluding jars, static resources etc.) into a ZIP file. The file name includes the application name and a timestamp. This is useful for reporting issues to the https://github.com/grails/grails-core/issues[Grails Issue Tracker]
+
+=== Examples
+
+
+[source,groovy]
+----
+grails bug-report
+----
+
+
+=== Description
+
+
+Usage:
+[source,groovy]
+----
+grails bug-report
+----

--- a/src/en/ref/Command Line/clean.adoc
+++ b/src/en/ref/Command Line/clean.adoc
@@ -1,0 +1,27 @@
+== clean
+
+
+
+=== Purpose
+
+
+The `clean` command deletes all compiled resources from the application. Since Groovy is a compiled language, as with Java, this is sometimes useful to clear old instances of classes and ensure correct compilation. It's also a good idea to run this script before running tests or creating a WAR file to ensure a full compilation occurs.
+
+
+=== Examples
+
+
+[source,groovy]
+----
+grails clean
+----
+
+
+=== Description
+
+
+Usage:
+[source,groovy]
+----
+grails clean
+----

--- a/src/en/ref/Command Line/compile.adoc
+++ b/src/en/ref/Command Line/compile.adoc
@@ -1,0 +1,26 @@
+== compile
+
+
+
+=== Purpose
+
+
+The `compile` command executes the compile phase of the Grails pre-packaging process, which compiles Groovy and Java sources.
+
+
+=== Examples
+
+
+----
+grails compile
+----
+
+
+=== Description
+
+
+Usage:
+[source,groovy]
+----
+grails compile
+----

--- a/src/en/ref/Command Line/console.adoc
+++ b/src/en/ref/Command Line/console.adoc
@@ -1,0 +1,29 @@
+== console
+
+=== Purpose
+
+Starts an instance of the Swing graphical Groovy console with an initialized Grails runtime.
+
+=== Examples
+
+[source,groovy]
+----
+grails console
+----
+
+=== Description
+
+
+Starts the Grails console, which is an extended version of the regular Groovy console. There are a couple of useful variables registered in the binding:
+
+* `ctx` - The Spring ApplicationContext instance
+* `grailsApplication` - The GrailsApplication instance
+
+These are useful as they allow access to the conventions within Grails and Spring beans.
+
+Usage:
+[source,groovy]
+----
+grails <<environment>>* console
+----
+

--- a/src/en/ref/Command Line/create-app.adoc
+++ b/src/en/ref/Command Line/create-app.adoc
@@ -8,6 +8,66 @@ The `create-app` command serves as the initial step in Grails application develo
 
 To create a Grails default web application, use the following command:
 
+[source,shell]
+----
+grails create-app [OPTIONS] name
+----
+
+- `NAME`: The desired name for the Grails application.
+
+Options include specifying features, configuring the GORM implementation, selecting a servlet implementation, choosing a test framework, setting the JDK version, and more. You can tailor your Grails plugin to your specific requirements using these options.
+
+=== Options
+
+Here are the available options for the create-app command:
+
+- `NAME`: The desired name for the application.
+- `-f, --features=FEATURE[,FEATURE...]`: Specifies the features to include. Available options include h2, scaffolding, gorm-hibernate5, spring-boot-starter-jetty, springloaded, spring-boot-starter-tomcat, micronaut-http-client, cache-ehcache, hibernate-validator, postgres, mysql, cache, database-migration, grails-gsp, hamcrest, gorm-mongodb, assertj, mockito, spring-boot-starter-undertow, micronaut-inject-groovy, github-workflow-java-ci, jrebel, testcontainers, sqlserver, grails-console, views-markup, asset-pipeline-grails, views-json, gorm-neo4j, asciidoctor, embedded-mongodb, grails-web-console, logbackGroovy, mongo-sync, shade, geb, properties.
+- `-g, --gorm=GORM Implementation`: Specifies the GORM Implementation to configure, with options like hibernate, mongodb, neo4j.
+- `-i, --inplace`: Creates a service within the current directory.
+- `--jdk=<javaVersion>`: Specifies the JDK version for the project.
+- `-s, --servlet=Servlet Implementation`: Specifies the Servlet Implementation, with choices including none, tomcat, jetty, undertow.
+- `-t, --test=TEST`: Specifies the test framework, with options such as junit, spock.
+
+=== Examples
+
+Here are examples for the `create-app` command:
+
+1. Create an application within a directory named "bookstore":
++
+[source,bash]
+----
+$ grails create-app bookstore
+$ cd bookstore
+----
+
+2. Create an application directly in the current directory:
++
+[source,bash]
+----
+$ mkdir bookstore
+$ cd bookstore
+$ grails create-app --inplace
+----
+
+3. Customize the application by adding specific features (available since Grails 3.1):
++
+[source,bash]
+----
+$ grails create-app bookstore --features github-workflow-java-ci,asciidoctor
+----
+
+
+== Grails Forge create-app
+
+=== Description
+
+The `create-app` command serves as the initial step in Grails application development. When invoked, this command generates a Grails application with a user-specified name. Subsequently, it creates a subdirectory based on the provided application name within the directory where the command is executed.
+
+=== Usage
+
+To create a Grails default web application, use the following command:
+
 [source,console]
 ----
 $ grails create-app [OPTIONS] name

--- a/src/en/ref/Command Line/create-command.adoc
+++ b/src/en/ref/Command Line/create-command.adoc
@@ -1,0 +1,80 @@
+== create-command
+
+=== Purpose
+
+
+The `create-command` command creates a new Grails Gradle task and shell command that can be run with the `grails` command from a terminal window.
+
+=== Examples
+
+The command:
+
+[source,groovy]
+----
+grails create-command MyExample
+----
+
+Creates a class called `grails-app/commands/PACKAGE_PATH/MyExampleCommand.groovy` such as:
+
+[source,groovy]
+----
+import grails.dev.commands.*
+
+class MyExampleCommand implements ApplicationCommand {
+
+  boolean handle(ExecutionContext ctx) {
+      def dataSource = applicationContext.getBean(DataSource)
+      return true
+  }
+}
+----
+
+Commands can be executed with the `runCommand` command.
+
+[source,java]
+----
+grails run-command my-example
+----
+
+Or as a Gradle task:
+
+[source,java]
+----
+gradle runCommand -Pargs="myExample"
+----
+
+If the command you are executing is defined in a plugin that you have declared a dependency on, then you can execute the command in short form like so:
+
+[source,groovy]
+----
+grails my-example
+----
+
+Or as a Gradle task:
+
+[source,groovy]
+----
+gradle myExample
+----
+
+The plugin is required be on both the build classpath and the runtime classpath in `build.gradle` in order for the short form to work:
+
+[source,groovy]
+----
+buildscript {
+  ...
+  dependencies {
+    classpath "org.grails.plugins:myplugin:0.1-SNAPSHOT"
+  }
+  ...
+  dependencies {
+    runtime "org.grails.plugins:myplugin:0.1-SNAPSHOT"
+  }
+}
+----
+
+=== Description
+
+In order to separate the code generation and build layer, in Grails 3.x scripts created with `create-script` do not have access to the running application instance.
+
+Instead, Grails 3.x features a new concept called an {apiDocs}grails/dev/commands/ApplicationCommand.html[ApplicationCommand] that is invoked via Gradle to perform tasks such as interact with classes in the runtime.

--- a/src/en/ref/Command Line/create-functional-test.adoc
+++ b/src/en/ref/Command Line/create-functional-test.adoc
@@ -1,0 +1,33 @@
+== create-functional-test
+
+=== Purpose
+
+The `create-functional-test` command creates a Geb functional test for the given base name.
+
+=== Examples
+
+[source,groovy]
+----
+grails create-functional-test
+grails create-functional-test book
+grails create-functional-test org.bookstore.Book
+----
+
+=== Description
+
+Creates an functional test for the given base name. The argument is optional, but if you don't include it the command will ask you for the name of the controller.
+
+An functional test differs from a unit test in that the Grails environment is loaded for the test execution. Refer to the section on link:{guidePath}/testing.html[Unit Testing] of the user guide for information on unit vs. functional testing.
+
+The name of the test can include a Java package, such as `org.bookstore` in the final example above, but if one is not provided a default is used. So the second example will create the file `test/integration/<appname>/BookSpec.groovy` whereas the last one will create `test/integration/org/bookstore/BookSpec.groovy` directory. Note that the first letter of the test name is always upper-cased when determining the class name.
+
+If you want the command to default to a different package for tests, provide a value for `grails.project.groupId` in the link:{guidePath}/conf.html[runtime configuration].
+
+Note that this command is just for convenience and you can also create functional tests in your favourite text editor or IDE if you choose.
+
+Usage:
+[source,groovy]
+----
+grails create-functional-test <<name>>
+----
+

--- a/src/en/ref/Command Line/create-hibernate-cfg-xml.adoc
+++ b/src/en/ref/Command Line/create-hibernate-cfg-xml.adoc
@@ -1,0 +1,22 @@
+== Purpose
+
+The create-hibernate-cfg-xml command will create a hibernate.cfg.xml file for custom Hibernate mappings.
+
+=== Examples
+
+[source,groovy]
+----
+grails create-hibernate-cfg-xml
+----
+
+=== Description
+
+Creates a hibernate.cfg.xml file in the grails-app/conf/hibernate directory. You can add <mapping> elements there to reference annotated Java domain classes, classes mapped by hbm.xml files, or hbm.xml files containing <database-object> elements defining custom DDL that's not supported by GORM.
+
+Usage:
+
+[source,groovy]
+----
+grails create-hibernate-cfg-xml
+----
+

--- a/src/en/ref/Command Line/create-integration-test.adoc
+++ b/src/en/ref/Command Line/create-integration-test.adoc
@@ -1,0 +1,34 @@
+== create-integration-test
+
+=== Purpose
+
+The `create-integration-test` command creates an integration test for the given base name.
+
+=== Examples
+
+[source,groovy]
+----
+grails create-integration-test
+grails create-integration-test book
+grails create-integration-test org.bookstore.Book
+----
+
+=== Description
+
+Creates an integration test for the given base name. The argument is optional, but if you don't include it the command will ask you for the name of the controller.
+
+An integration test differs from a unit test in that the Grails environment is loaded for each test execution. Refer to the section on link:{guidePath}/testing.html[Unit Testing] of the user guide for information on unit vs. integration testing.
+
+The name of the test can include a Java package, such as `org.bookstore` in the final example above, but if one is not provided a default is used. So the second example will create the file `src/integration-test/groovy/<appname>/BookSpec.groovy` whereas the last one will create `src/integration-test/groovy/org/bookstore/BookSpec.groovy` directory. Note that the first letter of the test name is always upper-cased when determining the class name.
+
+If you want the command to default to a different package for tests, provide a value for `grails.codegen.defaultPackage` in the link:{guidePath}/conf.html[runtime configuration].
+
+Note that this command is just for convenience and you can also create integration tests in your favourite text editor or IDE if you choose.
+
+Usage:
+[source,groovy]
+----
+grails create-integration-test <<name>>
+----
+
+

--- a/src/en/ref/Command Line/create-interceptor.adoc
+++ b/src/en/ref/Command Line/create-interceptor.adoc
@@ -1,0 +1,31 @@
+== create-interceptor
+
+=== Purpose
+
+The `create-interceptor` command creates an interceptor and associated unit test for the given base name.
+
+=== Examples
+
+----
+grails create-interceptor
+grails create-interceptor Book
+grails create-interceptor org.bookstore.book
+----
+
+=== Description
+
+Creates a new interceptor with an empty `before`, `after` and `afterView` method definitions. The argument is optional, but if you don't include it the command will ask you for the name of the interceptor.
+
+A link:{guidePath}/theWebLayer.html#interceptors[interceptor] is responsible intercepting incoming web requests and performing actions such as authentication, logging and so on.
+
+The name of the interceptor can include a Java package, such as `org.bookstore` in the final example above, but if one is not provided a default is used. So the second example will create the file `grails-app/controllers/<appname>/BookInterceptor.groovy` whereas the last one will create `grails-app/controllers/org/bookstore/BookInterceptor.groovy` directory. Note that the first letter of the interceptor name is always upper-cased when determining the class name.
+
+If you want the command to default to a different package for interceptors, provide a value for `grails.project.groupId` in the link:{guidePath}/conf.html[runtime configuration].
+
+Note that this command is just for convenience and you can also create interceptors in your favourite text editor or IDE if you choose.
+
+Usage:
+[source,groovy]
+----
+grails create-interceptor <<name>>
+----

--- a/src/en/ref/Command Line/create-plugin.adoc
+++ b/src/en/ref/Command Line/create-plugin.adoc
@@ -1,4 +1,32 @@
-== `create-plugin`
+== create-plugin
+
+=== Purpose
+
+The `create-plugin` command creates a Grails plugin project.
+
+=== Examples
+
+[source,groovy]
+----
+grails create-plugin simple
+----
+
+=== Description
+
+Creates a Grails plugin project. A Grails plugin project is just like an application project except it contains a plugin descriptor and can be packaged as a plugin and installed into other applications.
+
+Plugins are not just useful for plugin developers, but also as a way to modularize large Grails applications. Refer to the section on link:{guidePath}/plugins.html[Plugin Development] in the user guide for more information on developing plugins for Grails.
+
+Usage:
+
+[source,groovy]
+----
+grails create-plugin <<name>>
+----
+
+
+
+== Grails Forge `create-plugin`
 
 === Description
 

--- a/src/en/ref/Command Line/create-profile.adoc
+++ b/src/en/ref/Command Line/create-profile.adoc
@@ -1,0 +1,20 @@
+== create-profile
+
+=== Purpose
+
+The starting point for creating a Grails profile. This command will create a profile project with an appropriate Gradle build that can be published to your local Maven cache or a Maven repository.
+
+=== Examples
+
+[source,groovy]
+----
+grails create-profile mycompany
+----
+
+=== Description
+
+Usage:
+[source,groovy]
+----
+grails create-profile <<name>>
+----

--- a/src/en/ref/Command Line/create-script.adoc
+++ b/src/en/ref/Command Line/create-script.adoc
@@ -1,0 +1,54 @@
+== create-script
+
+=== Purpose
+
+The `create-script` command creates a new Grails code generation script that can be run with the `grails` command from a terminal window.
+
+=== Examples
+
+The command:
+
+[source,groovy]
+----
+grails create-script my-script
+----
+
+Creates a script called `src/main/scripts/my-script.groovy` such as:
+
+[source,groovy]
+----
+description "Example description", "grails example-usage"
+
+println "Example Script"
+----
+
+The command can then be run with:
+
+[source,groovy]
+----
+grails my-script
+----
+
+=== Description
+
+Each script extends from the super class {apiDocs}org/grails/cli/profile/commands/script/GroovyScriptCommand.html[GroovyScriptCommand] which provides an API for achieving a number of different tasks.
+
+=== Invoking Gradle
+
+You can invoke Gradle using the `gradle` property:
+
+[source,groovy]
+----
+gradle.assemble()
+----
+
+You can run any other Grails scripts by simply invoking the method:
+
+[source,groovy]
+----
+testApp()
+----
+
+Code generation can be performed using the {apiDocs}org/grails/cli/profile/commands/templates/TemplateRenderer.html[TemplateRenderer API]
+
+For more information, see the section on link:{guidePath}/commandLine.html#creatingCustomScripts[creating custom scripts].

--- a/src/en/ref/Command Line/create-unit-test.adoc
+++ b/src/en/ref/Command Line/create-unit-test.adoc
@@ -1,0 +1,36 @@
+== create-unit-test
+
+=== Purpose
+
+The `create-unit-test` command creates a unit test for the given base name.
+
+=== Examples
+
+[source,groovy]
+----
+grails create-unit-test
+grails create-unit-test book
+grails create-unit-test org.bookstore.Book
+----
+
+=== Description
+
+Creates a unit test for the given base name. The argument is optional, but if you don't include it the command will ask you for the name of the controller.
+
+A unit test differs from an integration test in that the Grails environment is not loaded for each test execution and it is left up to you to perform the appropriate mocking using http://spockframework.org/spock/docs/1.0/interaction_based_testing.html[Spock's mocking APIs].
+
+TIP: Refer to the section on link:{guidePath}/testing.html[Unit Testing] of the user guide for information on unit vs. integration testing.
+
+The name of the test can include a Java package, such as `org.bookstore` in the final example above, but if one is not provided a default is used. So the second example will create the file `test/integration/<appname>/BookSpec.groovy` whereas the last one will create `test/integration/org/bookstore/BookSpec.groovy` directory. Note that the first letter of the test name is always upper-cased when determining the class name.
+
+If you want the command to default to a different package for tests, provide a value for `grails.project.groupId` in the link:{guidePath}/conf.html[runtime configuration].
+
+Note that this command is just for convenience and you can also create integration tests in your favourite text editor or IDE if you choose.
+
+Usage:
+
+[source,groovy]
+----
+grails create-unit-test <<name>>
+----
+

--- a/src/en/ref/Command Line/dependency-report.adoc
+++ b/src/en/ref/Command Line/dependency-report.adoc
@@ -1,0 +1,32 @@
+
+== dependency-report
+
+
+
+=== Purpose
+
+
+The `dependency-report` command generates Ivy reports showing JAR dependencies required by the application.
+
+
+=== Examples
+
+
+----
+grails dependency-report
+grails dependency-report runtime
+----
+
+
+=== Description
+
+
+Usage:
+[source,groovy]
+----
+grails dependency-report <<configuration>>
+----
+
+Arguments:
+
+* `configuration` - optional configuration to generate a report for. If omitted reports for all configurations are generated

--- a/src/en/ref/Command Line/docs.adoc
+++ b/src/en/ref/Command Line/docs.adoc
@@ -1,0 +1,58 @@
+
+== docs
+
+
+
+=== Purpose
+
+
+Generates a user guide and Javadoc + Groovydoc API documentation for the current Grails project.
+
+
+=== Examples
+
+
+Add the plugin in your `build.gradle`:
+
+[source,groovy]
+----
+apply plugin: "org.grails.grails-doc"
+----
+
+Now run the command
+
+[source,groovy]
+----
+gradle docs
+----
+
+
+=== Description
+
+
+Some projects, particular plugins, benefit from documentation explaining how they work. Grails comes with its own documentation engine based on a wiki syntax that can generate both HTML and PDF versions of a user guide, just like the one you are currently reading. If you have the source for a user guide in `src/docs`, then this command will automatically generate the corresponding HTML and PDF documents.
+
+It's often useful to have API documentation as well. Since Grails is a mixed source framework, the command also generates both http://www.oracle.com/technetwork/java/javase/documentation/index-137868.html[Javadoc] (the standard format for Java documentation) and Groovydoc API references in HTML form.
+
+The documentation is generated to the following directories:
+
+* `docs/api` - Location of javadoc comments
+* `docs/gapi` - Location of groovydoc comments
+* `docs/guide` - Location of the user guide
+* `docs/ref` - Location of the reference section of the user guide
+
+Usage:
+[source,groovy]
+----
+grails doc
+----
+
+Arguments:
+
+* `\--init` - Create a template project documentation project (optional)
+* `\--pdf` - Create PDF output for project documentation (optional)
+
+Fired Events:
+
+* `DocStart` - Before documentation generation begins
+* `DocEnd` - After documentation generation completes

--- a/src/en/ref/Command Line/generate-all.adoc
+++ b/src/en/ref/Command Line/generate-all.adoc
@@ -1,4 +1,49 @@
-== Grails `generate-all` Command
+
+== generate-all
+
+
+
+=== Purpose
+
+
+Generates a controller, views, and a controller unit test for the given domain class
+
+
+=== Examples
+
+
+[source,groovy]
+----
+grails generate-all
+grails generate-all org.bookstore.Book
+grails generate-all "*"
+----
+
+
+=== Description
+
+
+Grails supports a feature known as static scaffolding which involves the generation of a CRUD (Create/Read/Update/Delete) interface for a given domain class. Once generated, the controller and its views can be modified by you but they won't automatically update when you change the domain class.
+
+The generate-all command generates an implementation of CRUD including a controller and views for the given domain class. The argument is optional, but if you don't include it the command will ask you for the name of the domain class to scaffold. So for a domain class `org.bookstore.Book`, this command will generate the controller `grails-app/controllers/org/bookstore/BookController.groovy` and its associated views in `grails-app/views/book`.
+
+Usage:
+[source,groovy]
+----
+grails generate-all <<name>>
+----
+
+Arguments:
+
+* `name` - Either a domain class name (case-sensitive) or a wildcard (\*). If you specify the wildcard then controllers and views will be generated for _all_ domain classes.
+
+Flags:
+
+* `force` - Whether to overwrite existing files
+
+
+
+== Gradle runCommand `generate-all` Command
 
 === Purpose
 

--- a/src/en/ref/Command Line/generate-controller.adoc
+++ b/src/en/ref/Command Line/generate-controller.adoc
@@ -1,4 +1,50 @@
-== Grails `generate-controller` Command
+
+== generate-controller
+
+
+
+=== Purpose
+
+
+Generates a controller and associated unit test for the given domain class
+
+
+=== Examples
+
+
+[source,groovy]
+----
+grails generate-controller
+grails generate-controller org.bookstore.Book
+grails generate-controller "*"
+----
+
+
+=== Description
+
+
+Grails supports a feature known as static scaffolding which involves the generation of a CRUD (Create/Read/Update/Delete) interface for a given domain class. Once generated, the controller and its views can be modified by you but they won't automatically update when you change the domain class.
+
+The `generate-controller` command generates just the controller (and associated unit test) that implements CRUD for the given domain class. The argument is optional, but if you don't include it the command will ask you for the name of the domain class to scaffold. So for a domain class `org.bookstore.Book`, this command will generate the controller `BookController.groovy` in `grails-app/controllers/org/bookstore`.
+
+Usage:
+[source,groovy]
+----
+grails generate-controller <<domain class name>>
+----
+
+
+Arguments:
+
+* `domain class name` - Either a domain class name (case-sensitive) or a wildcard (\*). If you specify the wildcard controllers will be generated for _all_ domain classes.
+
+Flags:
+
+* `force` - Whether to overwrite existing files
+
+
+
+== Gradle runCommand `generate-controller` Command
 
 === Purpose
 

--- a/src/en/ref/Command Line/generate-views.adoc
+++ b/src/en/ref/Command Line/generate-views.adoc
@@ -1,4 +1,46 @@
-== Grails `generate-views` Command
+
+== generate-views
+
+
+
+=== Purpose
+
+
+Generates GSP views for the given domain class
+
+
+=== Examples
+
+
+[source,groovy]
+----
+grails generate-views
+grails generate-views org.bookstore.Book
+grails generate-views "*"
+----
+
+
+=== Description
+
+
+Grails supports a feature known as static scaffolding which involves the generation of a CRUD (Create/Read/Update/Delete) interface for a given domain class. Once generated, the controller and its views can be modified by you but they won't automatically update when you change the domain class.
+
+The `generate-views` command generates just the GSP views that implement CRUD for the given domain class. The argument is optional, but if you don't include it the command will ask you for the name of the domain class to scaffold. So for a domain class `org.bookstore.Book`, the command will generate the appropriate 'list', 'show', 'create' and 'edit' views in `grails-app/views/book`.
+
+Usage:
+
+[source,groovy]
+----
+grails generate-views <<domain class name>>
+----
+
+Arguments:
+
+* `domain class name` - Either a domain class name (case-sensitive) or a wildcard (\*). If you specify the wildcard then views will be generated for _all_ domain classes.
+
+
+
+== Gradle runCommand `generate-views` Command
 
 === Purpose
 

--- a/src/en/ref/Command Line/help.adoc
+++ b/src/en/ref/Command Line/help.adoc
@@ -1,4 +1,40 @@
-== Grails `--help` Syntax
+
+== help
+
+
+
+=== Purpose
+
+
+Displays Grails command line help
+
+
+=== Examples
+
+
+[source,groovy]
+----
+grails help
+grails help run-app
+----
+
+
+=== Description
+
+
+Usage:
+[source,groovy]
+----
+grails help [command_name]*
+----
+
+Arguments:
+
+* `command_name` - The command name to display help for
+
+
+
+== Grails Forge `--help` Syntax
 
 === Purpose
 

--- a/src/en/ref/Command Line/install-templates.adoc
+++ b/src/en/ref/Command Line/install-templates.adoc
@@ -1,4 +1,37 @@
+
 == install-templates
+
+
+
+=== Purpose
+
+
+Copies the the templates used by Grails during code generation to your project directory
+
+
+=== Examples
+
+
+[source,groovy]
+----
+grails install-templates
+----
+
+
+=== Description
+
+
+Usage:
+
+[source,groovy]
+----
+grails install-templates
+----
+
+The `install-templates` command will copy the templates Grails uses for all code generation activities to the application's `src/main/templates/scaffolding` directory.
+
+
+== Gradle runCommand install-templates
 
 === Purpose
 

--- a/src/en/ref/Command Line/list-plugins.adoc
+++ b/src/en/ref/Command Line/list-plugins.adoc
@@ -1,0 +1,47 @@
+
+== list-plugins
+
+
+
+=== Purpose
+
+
+Lists the available plugins
+
+
+=== Examples
+
+
+[source,groovy]
+----
+grails list-plugins
+----
+
+
+=== Description
+
+
+Usage:
+[source,groovy]
+----
+grails list-plugins
+grails list-plugins -repository=myRepository
+----
+
+Lists the plugins that are installable. Note: This command can take a while to execute depending in your internet connectivity. Typical output looks like this:
+
+[source,groovy]
+----
+| Available Plugins
+* asset-pipeline
+* cache
+* cache-ehcache
+* fields
+* geb
+* hibernate
+* mongodb
+* quartz
+* scaffolding
+----
+
+If you require more info about a plugin you can use the link:plugin-info.html[plugin-info] command.

--- a/src/en/ref/Command Line/list-profiles.adoc
+++ b/src/en/ref/Command Line/list-profiles.adoc
@@ -1,0 +1,44 @@
+
+== list-profiles
+
+
+
+=== Purpose
+
+
+Lists the available profiles
+
+
+=== Examples
+
+
+[source,groovy]
+----
+grails list-profiles
+----
+
+
+=== Description
+
+
+Usage:
+[source,groovy]
+----
+grails list-profiles
+----
+
+Lists the profiles that are available. Note: This command can take a while to execute depending in your internet connectivity. Typical output looks like this:
+
+[source,groovy]
+----
+| Available Profiles
+--------------------
+* base - The base profile extended by other profiles
+* plugin - Profile for plugins designed to work across all profiles
+* profile - A profile for creating new Grails profiles
+* web - Profile for Web applications
+* rest-api - Profile for Web API applications
+* web-plugin - Profile for Plugins designed for Web applications
+----
+
+If you require more info about a profile you can use the link:profile-info.html[profile-info] command.

--- a/src/en/ref/Command Line/package-plugin.adoc
+++ b/src/en/ref/Command Line/package-plugin.adoc
@@ -1,0 +1,35 @@
+
+== package-plugin
+
+
+
+=== Purpose
+
+
+Packages a plugin as a JAR archive which can then be installed into another application
+
+
+=== Examples
+
+
+[source,groovy]
+----
+grails package-plugin
+----
+
+
+=== Description
+
+
+Usage:
+[source,groovy]
+----
+grails package-plugin
+----
+
+The plugin archive will be built to the `build/libs` directory by default. You can also install the plugin to your local Maven repository with the `install` command:
+
+[source,groovy]
+----
+grails install
+----

--- a/src/en/ref/Command Line/package.adoc
+++ b/src/en/ref/Command Line/package.adoc
@@ -1,0 +1,17 @@
+
+== package
+
+
+
+=== Purpose
+
+
+Runs the packaging phase of Grails' runtime. This is mainly useful when used by other scripts.
+
+
+=== Examples
+
+----
+grails package
+----
+

--- a/src/en/ref/Command Line/plugin-info.adoc
+++ b/src/en/ref/Command Line/plugin-info.adoc
@@ -1,0 +1,45 @@
+
+== plugin-info
+
+
+
+=== Purpose
+
+
+Displays detailed info about a plugin
+
+
+=== Examples
+
+
+[source,groovy]
+----
+grails plugin-info shiro
+----
+
+
+=== Description
+
+
+Usage:
+[source,groovy]
+----
+grails plugin-info <<name>>
+----
+
+This command will display more detailed info about a given plugin such as the author, location of documentation and so on. An example of the output of the geb plugin can be seen below:
+
+[source,groovy]
+----
+| Plugin Info: geb
+| Latest Version: 1.0.1-SNAPSHOT
+| All Versions: 1.0-SNAPSHOT,1.0.0.M1,1.0.0.M2,1.0.0.M3,1.0.0.M4,1.0.0,1.0.0.BUILD-SNAPSHOT,1.0.1-SNAPSHOT
+| Title: Geb Plugin
+
+Plugin that adds Geb functional testing code generation features.
+
+* License: APACHE
+* Documentation: http://grails.org/plugin/geb
+* Issue Tracker: http://github.com/grails3-plugins/geb/issues
+* Source: http://github.com/grails3-plugins/geb
+----

--- a/src/en/ref/Command Line/profile-info.adoc
+++ b/src/en/ref/Command Line/profile-info.adoc
@@ -1,0 +1,32 @@
+
+== profile-info
+
+
+
+=== Purpose
+
+
+Displays detailed info about a profile
+
+
+=== Examples
+
+
+[source,groovy]
+----
+grails profile-info rest-api
+grails profile-info org.grails.profiles:rest-api
+grails profile-info org.grails.profiles:rest-api:3.1.0
+----
+
+
+=== Description
+
+
+Usage:
+[source,groovy]
+----
+$ grails profile-info <<name>>
+----
+
+This command will display information about the given profile and expects an argument that is either the profile name or the fully qualified dependency coordinates.

--- a/src/en/ref/Command Line/run-app.adoc
+++ b/src/en/ref/Command Line/run-app.adoc
@@ -1,0 +1,49 @@
+== run-app
+
+=== Purpose
+
+Runs a Grails application in an embedded servlet container
+
+WARNING: This target is _not_ intended to be used for application deployment. There are many optimizations implemented when  generating a WAR file for deployment that are not available to `run-app` since `run-app` is optimized for developer productivity, not performance.
+
+=== Examples
+
+[source,groovy]
+----
+grails run-app
+grails run-app -https // with HTTPS
+grails test run-app
+----
+
+=== Description
+
+Usage:
+
+[source,groovy]
+----
+grails <<env>>* run-app
+----
+
+Arguments:
+
+* `debug-jvm` - Run the application using a debug JVM (port 5005) in order to attach a remote debugger.
+* `port` - The port to use
+* `host` - The host to bind to
+* `https` - Start an HTTPS server (on port 8443 by default) alongside the main server. Just to be clear, the application will be accessible via HTTPS _and_ HTTP. A self-signed key will be generated. Intended for development use only.
+
+Supported system properties:
+
+* `grails.server.port.http`/`server.port` - Specifies the HTTP port to run the server on (defaults to 8080)
+* `grails.server.port.https` - Specifies the HTTPS port to run the server on (defaults to 8443)
+* `grails.server.host`/`server.host` - Specifies the host name to run the server on (defaults to localhost)
+
+
+This command starts Grails in an embedded servlet container that can serve HTTP requests. The default container is http://tomcat.apache.org[Tomcat] but alternative containers are supported by altering the Spring boot starter in `build.gradle`.
+
+[source,groovy]
+----
+// use Jetty
+runtime "org.springframework.boot:spring-boot-starter-jetty"
+----
+
+For more information see the Spring Boot documentation on {springBootReference}/html/howto-embedded-web-servers.html[Embedded Containers].

--- a/src/en/ref/Command Line/run-command.adoc
+++ b/src/en/ref/Command Line/run-command.adoc
@@ -1,0 +1,36 @@
+
+===== run-command
+
+
+
+===== Purpose
+
+
+Execute Grails Commands defined in `grails-app/commands` or in plugins.
+
+
+===== Examples
+
+
+[source,java]
+----
+grails run-command hello-world
+
+./gradlew runCommand -Pargs="helloWorld"
+----
+
+The above scripts will expect `grails-app/commands/HelloWorldCommand.groovy` to exist in the application or in a plugin your application depends on.
+
+
+===== Description
+
+
+Usage:
+[source,java]
+----
+grails <<env>>* run-command <<command>>
+----
+
+Arguments:
+
+* `command` - Which command to run

--- a/src/en/ref/Command Line/run-script.adoc
+++ b/src/en/ref/Command Line/run-script.adoc
@@ -1,0 +1,49 @@
+
+===== run-script
+
+
+
+===== Purpose
+
+
+Execute Groovy script(s) in the context of a Grails environment.
+
+WARNING: Groovy scripts intended to be executed this way cannot be located in `src/main/scripts` because that directory is reserved for CLI scripts created by link:create-script.html[create-script].
+
+
+===== Examples
+
+
+[source,bash]
+----
+// run a single script in the dev environment
+grails run-script scripts/helloWorld.groovy
+
+// run multiple scripts in the prod environment
+grails prod run-script scripts/hello.groovy scripts/world.groovy
+
+// run with Gradle
+./gradlew runScript -Pargs="scripts/helloWorld.groovy" -Dgrails.env=prod
+----
+
+The paths are resolved relative to the base project path
+
+
+===== Description
+
+
+Usage:
+[source,bash]
+----
+grails <<env>>* run-script <<scripts>>
+----
+
+Arguments:
+
+* `scripts` - Which scripts to run
+
+Variables:
+
+The `ctx` variable is injected into all scripts and is an instance of the `ApplicationContext`
+
+NOTE: Scripts are executed in the context of a persistent session. The default package is imported by default (`grails.codegen.defaultPackage`)

--- a/src/en/ref/Command Line/schema-export.adoc
+++ b/src/en/ref/Command Line/schema-export.adoc
@@ -1,4 +1,62 @@
-= `schema-export` Command
+
+= schema-export
+
+
+
+== Purpose
+
+
+Uses Hibernate's SchemaExport tool to generate DDL or export the schema.
+NOTE: As of Grails 3, the Hibernate plugin is not by default on the build classpath. You need to add it to the build classpath to get the command working.
+
+
+== Examples
+
+
+[source,groovy]
+----
+//Add Hibernate to the build classpath
+buildscript {
+    dependencies {
+        classpath "org.grails.plugins:hibernate:4.3.8.0"
+    }
+}
+----
+
+
+[source,groovy]
+----
+grails schema-export
+grails schema-export --datasource=lookup
+grails prod schema-export
+grails dev schema-export
+grails prod schema-export export
+grails prod schema-export export --datasource=auditing
+grails prod schema-export stdout
+----
+
+
+== Description
+
+
+Usage:
+[source,groovy]
+----
+grails <<environment>> schema-export <<action>> ['stdout'] <<filename>> [--datasource]
+----
+
+Arguments:
+
+* `environment` - The environment containing the database configuration to use (dev, prod, etc...).
+* `action` - Either 'generate' or 'export'.  The default is 'generate'. Specifying 'export' will execute the script against the specified environment's database instead of just generating the ddl file.
+* `stdout` - Passing 'stdout' will cause the script to dump the ddl to stdout.
+* `filename` - The name of the file to write the ddl to.  The default is ddl.sql in the project's 'target' directory.
+* `datasource` - The `DataSource` name suffix; defaults to the default `DataSource` if not specified
+
+
+
+
+= Gradle runCommand `schema-export` Command
 
 == Purpose
 

--- a/src/en/ref/Command Line/shell.adoc
+++ b/src/en/ref/Command Line/shell.adoc
@@ -1,0 +1,45 @@
+
+== shell
+
+
+
+=== Purpose
+
+
+Starts an instance of the Groovy terminal shell with an initialized Grails runtime.
+
+
+=== Examples
+
+
+[source,groovy]
+----
+grails shell
+----
+
+
+=== Description
+
+
+Usage:
+[source,groovy]
+----
+grails <<environment>>* shell
+----
+
+Starts the Grails shell, which is an extended version of the regular Groovy shell. Within the binding of the shell there are a couple of useful variables:
+
+* `ctx` - The Spring ApplicationContext instance
+* `grailsApplication` - The GrailsApplication instance
+
+These are useful as they allow access to the conventions within Grails and Spring beans.
+
+Example Shell:
+
+[source,groovy]
+----
+Groovy Shell (1.8.0, JVM: 1.6.0_26)
+Type 'help' or '\h' for help.
+-----------------------------------
+groovy:000>
+----

--- a/src/en/ref/Command Line/stats.adoc
+++ b/src/en/ref/Command Line/stats.adoc
@@ -1,0 +1,27 @@
+
+== stats
+
+
+
+=== Purpose
+
+
+Displays basic statistics about the current Grails application, including number of files, line count and so on
+
+
+=== Examples
+
+
+[source,groovy]
+----
+> grails stats
++----------------------+-------+-------+
+| Name                 | Files |  LOC  |
++----------------------+-------+-------+
+| Controllers          |     1 |    66 |
+| Domain Classes       |     1 |     3 |
+| Integration Tests    |     2 |     8 |
++----------------------+-------+-------+
+| Totals               |     4 |    77 |
++----------------------+-------+-------+
+----

--- a/src/en/ref/Command Line/stop-app.adoc
+++ b/src/en/ref/Command Line/stop-app.adoc
@@ -1,0 +1,35 @@
+
+== stop-app
+
+
+
+=== Purpose
+
+
+Stops a running Grails application in an embedded servlet container.
+
+NOTE: This command will work in development mode only.
+
+
+=== Examples
+
+
+[source,groovy]
+----
+grails stop-app
+grails stop-app --port=9090 --host=mywebsite
+----
+
+
+=== Description
+
+
+Arguments:
+
+* `port` - Specifies the port which the Grails application is running on (defaults to 8080 for HTTP or 8443 for HTTPS)
+* `host` - Specifies the host the Grails application is bound to
+
+Supported system properties:
+
+* `server.port` - Same as `port` argument.
+* `server.address` - Same as `host` argument.

--- a/src/en/ref/Command Line/test-app.adoc
+++ b/src/en/ref/Command Line/test-app.adoc
@@ -1,0 +1,62 @@
+
+== test-app
+
+
+
+=== Purpose
+
+
+Runs all Grails unit and integration tests and generates reports. The command returns appropriate response codes for embedding with continuous integration servers.
+
+
+=== Examples
+
+
+[source,groovy]
+----
+grails test-app
+grails test-app Foo
+grails test-app Foo Bar
+----
+
+
+=== Description
+
+
+Usage:
+[source,groovy]
+----
+grails <<environment>>* test-app <<names>>* [-unit|-integration]
+----
+
+Fired Events:
+
+
+Executes the Grails unit and integration tests located in the `src/test/groovy` and `src/integration-test/groovy` directories. By default all tests are executed, but you can specify the names of the tests (without the "Tests" or other test type suffix) as argument to the command:
+
+[source,groovy]
+----
+grails test-app *Foo*
+grails test-app *Foo* *Bar*
+----
+
+The first example will execute a test called `FooSpec.groovy` whilst the second will execute `FooSpec.groovy` and `BarSpec.groovy` if they exist.
+
+The task of finding tests that match the pattern you provide is passed to Gradle. Take a look at the section in their docs titled link:https://docs.gradle.org/current/userguide/java_plugin.html#test_filtering[Test filtering] for more information.
+
+You can also choose to only run the unit or integration tests:
+
+[source,groovy]
+----
+grails test-app -unit
+grails test-app -integration
+----
+
+If you only wish to re-run failed tests use the -rerun flag
+
+[source,groovy]
+----
+grails test-app -rerun
+----
+
+See the link:{guidePath}/testing.html[Testing] section for examples on how to combine the different options to target tests.

--- a/src/en/ref/Command Line/war.adoc
+++ b/src/en/ref/Command Line/war.adoc
@@ -1,0 +1,51 @@
+
+== war
+
+
+
+=== Purpose
+
+
+The `war` command creates a Web Application Archive (WAR) file which can be deployed on any Java EE compliant application server.
+
+
+=== Examples
+
+
+[source,groovy]
+----
+grails war
+grails test war
+grails -Dgrails.env=staging war
+----
+
+
+=== Description
+
+
+Usage:
+[source,groovy]
+----
+grails <<environment>>* war <<arguments>>*
+----
+
+
+By default the `war` command creates a web application archive (WAR) file using the application name and version number. The `war` command is different from most commands since it runs in the production environment by default instead of development, but like any script the environment can be specified using the standard convention:
+
+[source,groovy]
+----
+grails test war
+grails dev war
+grails prod war
+----
+
+You can also specify a custom environment:
+
+[source,groovy]
+----
+grails -Dgrails.env=UAT war
+----
+
+Once the WAR has been created you can deploy it to your container using its standard WAR deployment process.
+
+NOTE: Grails 2.x `war` command allowed you to supply the argument `nojars` - which packaged the WAR with no jar files. In Grails 3.x, this argument is no longer available. Instead, you may use Gradle capabilities to generate a WAR without jar files. One option would be to set your dependencies as `providedCompile` and `providedRuntime`. Those two configurations have the same scope as the respective compile and runtime configurations, except that they are not added to the WAR archive. Check https://docs.gradle.org/current/userguide/war_plugin.html[Gradle WAR Plugin] documentation for more information.

--- a/src/en/ref/Plug-ins.adoc
+++ b/src/en/ref/Plug-ins.adoc
@@ -1,5 +1,33 @@
 
-=== Plugin Usage
+=== plugin Usage
+
+
+A plugin provides additional capability to the Grails runtime and is created with the link:../Command%20Line/create-plugin.html[create-plugin] command:
+
+[source,groovy]
+----
+grails create-plugin simple
+----
+
+This will create a plugin project which can then be packaged with link:../Command%20Line/package-plugin.html[package-plugin]:
+
+[source,groovy]
+----
+grails package-plugin
+----
+
+To install the plugin to your local Maven repository you can use the `install` command:
+
+[source,groovy]
+----
+grails install
+----
+
+Refer to the user guide topic on link:{guidePath}/plugins.html[plugins] for more information.
+
+
+
+=== Grails Forge Plugin Usage
 
 A plugin provides additional capability to the Grails runtime and is created with the link:../Command%20Line/create-plugin.html[create-plugin] command:
 


### PR DESCRIPTION
restore grails-shell cli commands and profiles documentation while maintaining grails forge and Gradle documentation

This was fairly complex and in cases where there was a new way, either Grails Forge CLI or Gradle, an effort was made to keep both.  This will make documentation longer, but attempts to include both ways of doing these tasks in Grails.

This PR is against the 6.2.x branch where grails-shell, profiles and these commands were restored for 6.2.1/6.2.2.  It will be merged up to the 7.0.x branch.  