### PR TITLE
Update Documentation for redirect Method to Include temporary Argument

### DIFF
--- a/src/en/ref/Controllers/redirect.adoc
+++ b/src/en/ref/Controllers/redirect.adoc
@@ -26,16 +26,23 @@ redirect(url: "https://www.blogjava.net/BlueSUN")
 
 redirect(Book.get(1))
 
+// For 302 Moved Temporarily
+redirect(action: "foo", permanent: false)
+
 // For 307 Temporary Redirect
-redirect(action: "foo", temporary: true)
+redirect(action: "foo", permanent: false, moved: false)
+
+// For 301 Moved Permanently Redirect (moved is default true)
+redirect(action: "foo", permanent: true)
 
 // For 308 Permanent Redirect
-redirect(action: "foo", permanent: true, temporary: true)
+redirect(action: "foo", permanent: true, moved: false)
+
 ----
 
 === Description
 
-Redirects the current action to another action, optionally passing parameters and/or errors. When issuing a redirect from a namespaced controller, the namespace for the target controller is implied to be that of the controller initiating the redirect. To issue a redirect from a namespaced controller to a controller that is not in a namespace, the namespace must be explicitly specified with a value of `null` as shown below.
+Redirects the current action to another action, optionally passing parameters and/or errors. When issuing a redirect from a namespaced controller, the namespace for the target controller is implied to be that of the controller initiating the redirect. To issue a redirect from a namespaced controller to a controller that is not in a namespace, the namespace must be explicitly specified with a value of `null` as shown below.  By default, the redirect code will be MOVED_TEMPORARILY (302).
 
 [source,groovy]
 ----
@@ -64,8 +71,8 @@ class SomeController {
 * `url` (optional) - a map containing the action, controller, id, etc.
 * `absolute` (optional) - If `true` (default) will prefix the link target address with the value of the `grails.serverURL` property from `application.yml`, or http://localhost:<port> if there is no value in `application.yml` and not running in the production environment. If `false` a partial URI is generated for the `Location` header.
 * `base` (optional) - Sets the prefix to be added to the link target address, typically an absolute server URL. This overrides the behaviour of the `absolute` property if both are specified.
-* `permanent` (optional) - If `true`, the redirect will be issued with a 301 HTTP status code (permanently moved); otherwise, a 302 HTTP status code will be issued.
-* `temporary` (optional) - If `true`, the redirect will use HTTP status codes 307 (temporary) or 308 (permanent temporary) based on the `permanent` flag.
+* `permanent` (optional) - Defaults to `false`.  If `true`, the redirect will be issued with a PERMANENT style HTTP status code. If `moved` is true: MOVED_PERMANENTLY (301). Otherwise, PERMANENT_REDIRECT (308).
+* `moved` (optional) - Defaults to `true`.  When `true`, the redirect will be issued with a MOVED style HTTP status code. If `permanent` is true: MOVED_PERMANTENTLY (301). Otherwise, MOVED_TEMPORARILY (302).
 
 === Domain Class
 

--- a/src/en/ref/Controllers/redirect.adoc
+++ b/src/en/ref/Controllers/redirect.adoc
@@ -1,16 +1,10 @@
-
 == redirect
-
-
 
 === Purpose
 
-
 To redirect flow from one action to the next using an HTTP redirect.
 
-
 === Examples
-
 
 [source,groovy]
 ----
@@ -31,13 +25,17 @@ redirect(uri: "book/list")
 redirect(url: "https://www.blogjava.net/BlueSUN")
 
 redirect(Book.get(1))
-----
 
+// For 307 Temporary Redirect
+redirect(action: "foo", temporary: true)
+
+// For 308 Permanent Redirect
+redirect(action: "foo", permanent: true, temporary: true)
+----
 
 === Description
 
-
-Redirects the current action to another action, optionally passing parameters and/or errors.  When issuing a redirect from a namespaced controller, the namespace for the target controller is implied to be that of the controller initiating the redirect.  To issue a redirect from a namespaced controller to a controller that is not in a namespace, the namespace must be explicitly specified with a value of `null` as shown below.
+Redirects the current action to another action, optionally passing parameters and/or errors. When issuing a redirect from a namespaced controller, the namespace for the target controller is implied to be that of the controller initiating the redirect. To issue a redirect from a namespaced controller to a controller that is not in a namespace, the namespace must be explicitly specified with a value of `null` as shown below.
 
 [source,groovy]
 ----
@@ -51,7 +49,6 @@ class SomeController {
 }
 ----
 
-
 === Parameters
 
 `redirect(Map params)`
@@ -64,13 +61,14 @@ class SomeController {
 * `fragment` (optional) - The link fragment (often called anchor tag) to use
 * `mapping` (optional) - The <<namedMappings,named URL mapping>> to use to rewrite the link
 * `params` (optional) - a map containing request parameters
-* `url` (optional) - a map containing the action, controller, id etc.
+* `url` (optional) - a map containing the action, controller, id, etc.
 * `absolute` (optional) - If `true` (default) will prefix the link target address with the value of the `grails.serverURL` property from `application.yml`, or http://localhost:<port> if there is no value in `application.yml` and not running in the production environment. If `false` a partial URI is generated for the `Location` header.
 * `base` (optional) - Sets the prefix to be added to the link target address, typically an absolute server URL. This overrides the behaviour of the `absolute` property if both are specified.
-* `permanent` (optional) - If `true` the redirect will be issued with a 301 HTTP status code (permanently moved), otherwise a 302 HTTP status code will be issued
+* `permanent` (optional) - If `true`, the redirect will be issued with a 301 HTTP status code (permanently moved); otherwise, a 302 HTTP status code will be issued.
+* `temporary` (optional) - If `true`, the redirect will use HTTP status codes 307 (temporary) or 308 (permanent temporary) based on the `permanent` flag.
 
 === Domain Class
 
 `redirect(Object domainClass)`
 
-A special case is if a domain class is passed into `redirect` it will use the `LinkGenerator` to create the URL. For example `redirect(Book.get(1))` will generate a redirect to `/book/show/1`.
+A special case is if a domain class is passed into `redirect`, it will use the `LinkGenerator` to create the URL. For example, `redirect(Book.get(1))` will generate a redirect to `/book/show/1`.


### PR DESCRIPTION
This pull request updates the [redirect.adoc] file to document the newly added temporary argument for the redirect method. The temporary argument allows developers to specify HTTP 307 (Temporary Redirect) and HTTP 308 (Permanent Redirect) status codes, enhancing the flexibility of redirect behavior in Grails applications.


Changes Made:

Examples Section:

Added examples demonstrating the usage of the temporary argument:
redirect(action: "foo", temporary: true) for HTTP 307 Temporary Redirect.
redirect(action: "foo", permanent: true, temporary: true) for HTTP 308 Permanent Redirect.
Parameters Section:

Documented the temporary argument:
If true, the redirect will use HTTP status codes 307 (temporary) or 308 (permanent temporary) based on the permanent flag.
Consistency:

Ensured the documentation aligns with the existing style and structure of the redirect method documentation.

Issue Fixed: This PR addresses the request to update the documentation for the redirect method to include the new temporary argument, as per the changes introduced in #14092.