### PR TITLE
Move the app context path example url

### DIFF
--- a/src/en/guide/gettingStarted/aHelloWorldExample.adoc
+++ b/src/en/guide/gettingStarted/aHelloWorldExample.adoc
@@ -132,14 +132,13 @@ server:
         context-path: /myapp
 ----
 
-With this configuration, the application will be available at:
+With this configuration, the application will be available at: http://localhost:8080/myapp/
 
 Alternatively, you can also set the context path via the command line:
 [source,bash]
 ----
 grails> run-app -Dgrails.server.servlet.context-path=/helloworld
 ----
-http://localhost:8080/myapp/
 
 Alternatively, you can set the context path from the command line when using Gradle to run a Grails application. Here's how you can do it:
 


### PR DESCRIPTION
The Getting Started sections Optional: Set a Context Path explains how a configuration property be set in the application.yaml file but the corresponding link explaining how that configuration is accessible is missing or misplaced.

Link : https://docs.grails.org/7.0.0-M3/guide/single.html#introduction
```
If you want to set a context path for your application, create a configuration property in the "grails-app/conf/application.yml" file:

server:
    servlet:
        context-path: /myapp
With this configuration, the application will be available at:

Alternatively, you can also set the context path via the command line:

grails> run-app -Dgrails.server.servlet.context-path=/helloworld

http://localhost:8080/myapp/
```
This must have to be:
`With this configuration, the application will be available at: http://localhost:8080/myapp`

Issue: https://github.com/apache/grails-doc/issues/967